### PR TITLE
fix(twin,amqp): refactor AMQP implementation of the twin

### DIFF
--- a/device/transport/amqp/devdoc/amqp_twin_client_requirements.md
+++ b/device/transport/amqp/devdoc/amqp_twin_client_requirements.md
@@ -3,29 +3,117 @@
 ## Overview
 Object used to subscribe to the Cloud-to-Device messages for Twin
 
-## Example
-```javascript
-var receiver = new AmqpTwinClient(config: ClientConfig, client: any);
-receiver.on('response', function(response) {
-    console.log('Response received for request ' + response.requestId);
-    console.log('  status = " + response.status);
-    console.log(response.body);
-});
-```
-
 ## Public API
 
-### Constructor
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_004: [** The `AmqpTwinClient` constructor shall throw `ReferenceError` if the `config` object is falsy. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_002: [** The `AmqpTwinClient` constructor shall throw `ReferenceError` if the `client` object is falsy. **]**
+```typescript
+class AmqpTwinClient extends EventEmitter {
+  constructor(authenticationProvider: AuthenticationProvider, client: any) {
+  getTwin(callback: (err: Error, twin?: TwinProperties) => void): void;
+  updateTwinReportedProperties(patch: any, callback: (err?: Error) => void): void;
+  enableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void;
+  disableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void;
+  detach(callback: (err?: Error) => void): void;
+}
+```
+### constructor(authenticationProvider: AuthenticationProvider, client: any) {
 
 **SRS_NODE_DEVICE_AMQP_TWIN_06_005: [** The `AmqpDeviceMethodClient` shall inherit from the `EventEmitter` class. **]**
 
-### response event
+### getTwin(callback: (err: Error, twin?: TwinProperties) => void): void;
 
-**SRS_NODE_DEVICE_AMQP_TWIN_06_006: [** When a listener is added for the `response` event, and the `post` event is NOT already subscribed, upstream and downstream links are established via calls to `attachReceiverLink` and `attachSenderLink`. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_16_007: [** The `getTwin` method shall attach the sender link if it's not already attached. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_008: [** If attaching the sender link fails, the `getTwin` method shall call its callback with the error that caused the failure. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_009: [** THe `getTwin` method shall attach the receiver link if it's not already attached. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_010: [** If attaching the receiver link fails, the `getTwin` method shall call its callback with the error that caused the failure. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_011: [** The `getTwin` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+- `operation` annotation set to `GET`.
+- `resource` annotation set to `undefined`
+- `correlationId` property set to a random integer
+- `body` set to ` `. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_012: [** If the `SenderLink.send` call fails the `getTwin` method shall call its callback with the error that caused the failure. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_013: [** The `getTwin` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_014: [** The `getTwin` method shall parse the body of the received message and call its callback with a `null` error object and the parsed object as a result. **]**
+
+### updateTwinReportedProperties(patch: any, callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_015: [** The `updateTwinReportedProperties` method shall attach the sender link if it's not already attached. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_016: [** If attaching the sender link fails, the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_017: [** THe `updateTwinReportedProperties` method shall attach the receiver link if it's not already attached. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_018: [** If attaching the receiver link fails, the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_019: [** The `updateTwinReportedProperties` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+- `operation` annotation set to `PATCH`.
+- `resource` annotation set to `/properties/reported`
+- `correlationId` property set to a random integer
+- `body` set to the stringified patch object. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_020: [** If the `SenderLink.send` call fails the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_021: [** The `updateTwinReportedProperties` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_022: [** The `updateTwinReportedProperties` method shall call its callback with no argument when a response is received **]**
+// TODO: we need to check error codes!
+
+
+### enableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_023: [** The `enableTwinDesiredPropertiesUpdates` method shall attach the sender link if it's not already attached. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_024: [** If attaching the sender link fails, the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_025: [** THe `enableTwinDesiredPropertiesUpdates` method shall attach the receiver link if it's not already attached. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_026: [** If attaching the receiver link fails, the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_027: [** The `enableTwinDesiredPropertiesUpdates` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+- `operation` annotation set to `PUT`.
+- `resource` annotation set to `/notifications/twin/properties/desired`
+- `correlationId` property set to a random integer
+- `body` set to `undefined`. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_028: [** If the `SenderLink.send` call fails the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_029: [** The `enableTwinDesiredPropertiesUpdates` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_030: [** The `enableTwinDesiredPropertiesUpdates` method shall call its callback with no argument when a response is received **]**
+// TODO: we need to check error codes!
+
+### disableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_031: [** The `disableTwinDesiredPropertiesUpdates` method shall call its callback immediately and with no arguments if the links are detached. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_032: [** The `disableTwinDesiredPropertiesUpdates` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+- `operation` annotation set to `DELETE`.
+- `resource` annotation set to `/notifications/twin/properties/desired`
+- `correlationId` property set to a random integer
+- `body` set to `undefined`. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_033: [** If the `SenderLink.send` call fails the `disableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_034: [** The `disableTwinDesiredPropertiesUpdates` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_035: [** The `disableTwinDesiredPropertiesUpdates` method shall call its callback with no argument when a response is received **]**
+// TODO: we need to check error codes!
+
+### detach(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_004: [** The `detach` method shall call its `callback` immediately if the links are already detached. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_005: [** The `detach` method shall detach the links and call its `callback` with no arguments if the links are successfully detached. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_006: [** The `detach` method shall call its `callback` with an `Error` if detaching either of the links fail. **]**
+
+### Links
 
 **SRS_NODE_DEVICE_AMQP_TWIN_06_007: [** The endpoint argument for attacheReceiverLink shall be `/devices/<deviceId>/twin`. **]**
 
@@ -51,58 +139,3 @@ receiver.on('response', function(response) {
         sndSettleMode: 1,
         rcvSettleMode: 0
       } **]**
-.
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_011: [** Upon successfully establishing the upstream and downstream links the `subscribed` event shall be emitted from the twin receiver, with an argument object of {eventName: "response", transportObject: <object>}. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_015: [** If there is a listener for the `response` event, a `response` event shall be emitted for each response received for requests initiated by SendTwinRequest. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_014: [** When there are no more listeners for the `response` AND the `post` event, the upstream and downstream amqp links shall be closed via calls to `detachReceiverLink` and `detachSenderLink`. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_016: [** When a `response` event is emitted, the parameter shall be an object which contains `status`, `requestId` and `body` members. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_017: [** The `requestId` value is acquired from the amqp message correlationId property in the response amqp message. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_026: [** The `status` value is acquired from the amqp message status message annotation. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_018: [** The `body` parameter of the `response` event shall be the data of the received amqp message. **]**
-
-#### post event
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_012: [** When a listener is added for the `post` event, and the `response` event is NOT already subscribed, upstream and downstream links are established via calls to `attachReceiverLink` and `attachSenderLine`. **]**
-
-The endpoints and link options are as for the response event.
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_019: [** Upon successfully establishing the upstream and downstream links, a `PUT` request shall be sent on the upstream link with a correlationId set in the properties of the amqp message. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_013: [** Upon receiving a successful response message with the correlationId of the `PUT`, the `subscribed` event shall be emitted from the twin receiver, with an argument object of {eventName: "post", transportObject: <object>}. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_020: [** If there is a listener for the `post` event, a `post` event shall be emitted for each amqp message received on the downstream link that does NOT contain a correlation id, the parameter of the emit will be is the data of the amqp message. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_021: [** When there is no more listeners for the `post` event, a `DELETE` request shall be sent on the upstream link with a correlationId set in the properties of the amqp message. **]**
-
-### error
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_022: [** If an error occurs on establishing the upstream or downstream link then the `error` event shall be emitted. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_025: [** When the `error` event is emitted, the first parameter shall be an error object obtained via the amqp `translateError` module. **]**
-
-### attach(callback)
-
-**SRS_NODE_DEVICE_AMQP_TWIN_16_001: [** The `attach` method shall attach both sender and receiver links and calls its `callback` with no argument if successful. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_16_002: [** The `attach` method shall call its `callback` with an `Error` if attaching either link fails. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_16_003: [** The `attach` method shall call its `callback` immediately if the links are already attached. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_16_007: [** The `attach` method shall call the `getDeviceCredentials` method on the `authenticationProvider` object passed as an argument to the constructor to retrieve the device id. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_16_008: [** The `attach` method shall call its callback with an error if the call to `getDeviceCredentials` fails with an error. **]**
-
-### detach(callback)
-
-**SRS_NODE_DEVICE_AMQP_TWIN_16_004: [** The `detach` method shall call its `callback` immediately if the links are already detached. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_16_005: [** The `detach` method shall detach the links and call its `callback` with no arguments if the links are successfully detached. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_16_006: [** The `detach` method shall call its `callback` with an `Error` if detaching either of the links fail. **]**

--- a/device/transport/amqp/devdoc/amqp_twin_client_requirements.md
+++ b/device/transport/amqp/devdoc/amqp_twin_client_requirements.md
@@ -17,7 +17,7 @@ class AmqpTwinClient extends EventEmitter {
 ```
 ### constructor(authenticationProvider: AuthenticationProvider, client: any) {
 
-**SRS_NODE_DEVICE_AMQP_TWIN_06_005: [** The `AmqpDeviceMethodClient` shall inherit from the `EventEmitter` class. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_06_005: [** The `AmqpTwinClient` shall inherit from the `EventEmitter` class. **]**
 
 ### getTwin(callback: (err: Error, twin?: TwinProperties) => void): void;
 
@@ -32,12 +32,12 @@ class AmqpTwinClient extends EventEmitter {
 **SRS_NODE_DEVICE_AMQP_TWIN_16_011: [** The `getTwin` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
 - `operation` annotation set to `GET`.
 - `resource` annotation set to `undefined`
-- `correlationId` property set to a random integer
+- `correlationId` property set to a uuid
 - `body` set to ` `. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_16_012: [** If the `SenderLink.send` call fails the `getTwin` method shall call its callback with the error that caused the failure. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_16_012: [** If the `SenderLink.send` call fails, the `getTwin` method shall call its callback with the error that caused the failure. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_16_013: [** The `getTwin` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_16_013: [** The `getTwin` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler until a message with the same `correlationId` as the one that was sent is received. **]**
 
 **SRS_NODE_DEVICE_AMQP_TWIN_16_014: [** The `getTwin` method shall parse the body of the received message and call its callback with a `null` error object and the parsed object as a result. **]**
 
@@ -54,12 +54,12 @@ class AmqpTwinClient extends EventEmitter {
 **SRS_NODE_DEVICE_AMQP_TWIN_16_019: [** The `updateTwinReportedProperties` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
 - `operation` annotation set to `PATCH`.
 - `resource` annotation set to `/properties/reported`
-- `correlationId` property set to a random integer
+- `correlationId` property set to a uuid
 - `body` set to the stringified patch object. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_16_020: [** If the `SenderLink.send` call fails the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_16_020: [** If the `SenderLink.send` call fails, the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_16_021: [** The `updateTwinReportedProperties` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_16_021: [** The `updateTwinReportedProperties` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler until a message with the same `correlationId` as the one that was sent is received. **]**
 
 **SRS_NODE_DEVICE_AMQP_TWIN_16_022: [** The `updateTwinReportedProperties` method shall call its callback with no argument when a response is received **]**
 // TODO: we need to check error codes!
@@ -78,12 +78,12 @@ class AmqpTwinClient extends EventEmitter {
 **SRS_NODE_DEVICE_AMQP_TWIN_16_027: [** The `enableTwinDesiredPropertiesUpdates` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
 - `operation` annotation set to `PUT`.
 - `resource` annotation set to `/notifications/twin/properties/desired`
-- `correlationId` property set to a random integer
+- `correlationId` property set to a uuid
 - `body` set to `undefined`. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_16_028: [** If the `SenderLink.send` call fails the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_16_028: [** If the `SenderLink.send` call fails, the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_16_029: [** The `enableTwinDesiredPropertiesUpdates` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_16_029: [** The `enableTwinDesiredPropertiesUpdates` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler until a message with the same `correlationId` as the one that was sent is received. **]**
 
 **SRS_NODE_DEVICE_AMQP_TWIN_16_030: [** The `enableTwinDesiredPropertiesUpdates` method shall call its callback with no argument when a response is received **]**
 // TODO: we need to check error codes!
@@ -95,12 +95,12 @@ class AmqpTwinClient extends EventEmitter {
 **SRS_NODE_DEVICE_AMQP_TWIN_16_032: [** The `disableTwinDesiredPropertiesUpdates` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
 - `operation` annotation set to `DELETE`.
 - `resource` annotation set to `/notifications/twin/properties/desired`
-- `correlationId` property set to a random integer
+- `correlationId` property set to a uuid
 - `body` set to `undefined`. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_16_033: [** If the `SenderLink.send` call fails the `disableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_16_033: [** If the `SenderLink.send` call fails, the `disableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_16_034: [** The `disableTwinDesiredPropertiesUpdates` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_16_034: [** The `disableTwinDesiredPropertiesUpdates` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler until a message with the same `correlationId` as the one that was sent is received. **]**
 
 **SRS_NODE_DEVICE_AMQP_TWIN_16_035: [** The `disableTwinDesiredPropertiesUpdates` method shall call its callback with no argument when a response is received **]**
 // TODO: we need to check error codes!
@@ -115,9 +115,9 @@ class AmqpTwinClient extends EventEmitter {
 
 ### Links
 
-**SRS_NODE_DEVICE_AMQP_TWIN_06_007: [** The endpoint argument for attacheReceiverLink shall be `/devices/<deviceId>/twin`. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_06_007: [** The endpoint argument for `attachReceiverLink` shall be `/devices/<deviceId>/twin`. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_06_008: [** The link options argument for attachReceiverLink shall be:
+**SRS_NODE_DEVICE_AMQP_TWIN_06_008: [** The link options argument for `attachReceiverLink` shall be:
  attach: {
         properties: {
           'com.microsoft:channel-correlation-id' : 'twin:<correlationId>',
@@ -128,9 +128,9 @@ class AmqpTwinClient extends EventEmitter {
       } **]**
 
 
-**SRS_NODE_DEVICE_AMQP_TWIN_06_009: [** The endpoint argument for attacheSenderLink shall be `/device/<deviceId>/twin`. **]**
+**SRS_NODE_DEVICE_AMQP_TWIN_06_009: [** The endpoint argument for `attachSenderLink` shall be `/device/<deviceId>/twin`. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_06_010: [** The link options argument for attachSenderLink shall be:
+**SRS_NODE_DEVICE_AMQP_TWIN_06_010: [** The link options argument for `attachSenderLink` shall be:
  attach: {
         properties: {
           'com.microsoft:channel-correlation-id' : 'twin:<correlationId>',
@@ -139,3 +139,5 @@ class AmqpTwinClient extends EventEmitter {
         sndSettleMode: 1,
         rcvSettleMode: 0
       } **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_036: [** The same correlationId shall be used for both the sender and receiver links. **]**

--- a/device/transport/amqp/devdoc/device_amqp_requirements.md
+++ b/device/transport/amqp/devdoc/device_amqp_requirements.md
@@ -152,61 +152,6 @@ This method is deprecated. The `AmqpReceiver` object and pattern is going away a
 
 **SRS_NODE_DEVICE_AMQP_16_020: [** The `sendMethodResponse` response shall call the `AmqpDeviceMethodClient.sendMethodResponse` method with the arguments that were given to it. **]**
 
-### sendTwinRequest(method, resource, properties, body, done)
-
-**SRS_NODE_DEVICE_AMQP_06_012: [** The `sendTwinRequest` method shall not throw `ReferenceError` if the `done` callback is falsy. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_013: [** The `sendTwinRequest` method shall throw an `ReferenceError` if the `method` argument is falsy. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_014: [** The `sendTwinRequest` method shall throw an `ReferenceError` if the `resource` argument is falsy. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_015: [** The `sendTwinRequest` method shall throw an `ReferenceError` if the `properties` argument is falsy. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_016: [** The `sendTwinRequest` method shall throw an `ReferenceError` if the `body` argument is falsy. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_017: [** The `sendTwinRequest` method shall throw an `ArgumentError` if the `method` argument is not a string. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_018: [** The `sendTwinRequest` method shall throw an `ArgumentError` if the `resource` argument is not a string. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_019: [** The `sendTwinRequest` method shall throw an `ArgumentError` if the `properties` argument is not a an object. **]**
-
-An new Amqp message shall be instantiated.
-
-**SRS_NODE_DEVICE_AMQP_06_020: [** The `method` argument shall be the value of the amqp message `operation` annotation. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_021: [** The `resource` argument shall be the value of the amqp message `resource` annotation. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_031: [** If the `resource` argument terminates in a slash, the slash shall be removed from the annotation. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_039: [** If the `resource` argument length is zero (after terminating slash removal), the resource annotation shall not be set. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_028: [** The `sendTwinRequest` method shall throw an `ArgumentError` if any members of the `properties` object fails to serialize to a string. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_022: [** All properties, except $rid, shall be set as the part of the properties map of the amqp message. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_023: [** The $rid property shall be set as the `correlationId` in the properties map of the amqp message. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_024: [** The `body` shall be value of the body of the amqp message. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_025: [** The amqp message will be sent upstream to the IoT Hub via the amqp client `send`. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_040: [** If an error occurs in the `sendTwinRequest` method, the `done` callback shall be called with the error as the first parameter. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_041: [** If an error occurs, the `sendTwinRequest` shall use the AMQP `translateError` module to convert the amqp-specific error to a transport agnostic error before passing it into the `done` callback. **]**
-
-**SRS_NODE_DEVICE_AMQP_06_042: [** If the `sendTwinRequest` method is successful, the first parameter to the `done` callback shall be null and the second parameter shall be a MessageEnqueued object. **]**
-
-### getTwinReceiver(done)
-
-**SRS_NODE_DEVICE_AMQP_06_033: [** The `getTwinReceiver` method shall throw an `ReferenceError` if done is falsy **]**
-
-**SRS_NODE_DEVICE_AMQP_16_026: [** The `getTwinReceiver` method shall call the `done` callback with a `null` error argument and the `AmqpTwinClient` instance created when the `Amqp` object was instantiated. **]**
-
-**SRS_NODE_DEVICE_AMQP_16_027: [** The `getTwinReceiver` method shall connect and authenticate the AMQP connection if necessary. **]**
-
-**SRS_NODE_DEVICE_AMQP_16_028: [** The `getTwinReceiver` method shall call the `done` callback with the corresponding error if the transport fails connect or authenticate the AMQP connection. **]**
-
-
 ### onDeviceMethod(methodName, methodCallback)
 
 **SRS_NODE_DEVICE_AMQP_RECEIVER_16_007: [** The `onDeviceMethod` method shall forward the `methodName` and `methodCallback` arguments to the underlying `AmqpDeviceMethodClient` object. **]**
@@ -249,20 +194,53 @@ An new Amqp message shall be instantiated.
 **SRS_NODE_DEVICE_AMQP_16_044: [** The `disableMethods` method shall call its `callback` immediately if the transport is already disconnected. **]**
 
 
-### enableTwin(callback)
+### getTwin(callback: (err?: Error, twin?: TwinProperties) => void): void;
 
-**SRS_NODE_DEVICE_AMQP_16_045: [** The `enableTwin` method shall connect and authenticate the transport if it is disconnected. **]**
+**SRS_NODE_DEVICE_AMQP_16_059: [** The `getTwin` method shall connect and authenticate the transport if it is disconnected. **]**
 
-**SRS_NODE_DEVICE_AMQP_16_046: [** The `enableTwin` method shall attach the twin links and call its `callback` once these are successfully attached. **]**
+**SRS_NODE_DEVICE_AMQP_16_060: [** The `getTwin` method shall call its callback with an error if connecting fails. **]**
 
-**SRS_NODE_DEVICE_AMQP_16_047: [** The `enableTwin` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach twin links. **]**
+**SRS_NODE_DEVICE_AMQP_16_061: [** The `getTwin` method shall call its callback with an error if authenticating fails. **]**
 
-**SRS_NODE_DEVICE_AMQP_16_048: [** Any `error` event received on any of the links used for twin shall trigger the emission of an `error` event by the transport, with an argument that is a `TwinDetachedError` object with the `innerError` property set to that error. **]**
+**SRS_NODE_DEVICE_AMQP_16_062: [** The `getTwin` method shall call the `getTwin` method on the `AmqpTwinClient` instance created by the constructor. **]**
 
-### disableTwin(callback)
+**SRS_NODE_DEVICE_AMQP_16_063: [** The `getTwin` method shall call its callback with and error if the call to `AmqpTwinClient.getTwin` fails. **]**
 
-**SRS_NODE_DEVICE_AMQP_16_049: [** The `disableTwin` method shall call `detach` on the twin links and call its callback when these are successfully detached. **]**
+**SRS_NODE_DEVICE_AMQP_16_064: [** The `getTwin` method shall call its callback with a `null` error parameter and the result of the `AmqpTwinClient.getTwin` method if it succeeds. **]**
 
-**SRS_NODE_DEVICE_AMQP_16_050: [** The `disableTwin` method shall call its `callback` with an `Error` if it fails to detach the twin links. **]**
 
-**SRS_NODE_DEVICE_AMQP_16_051: [** The `disableTwin` method shall call its `callback` immediately if the transport is already disconnected. **]**
+### updateTwinReportedProperties(patch: any, callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_16_065: [** The `updateTwinReportedProperties` method shall connect and authenticate the transport if it is disconnected. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_066: [** The `updateTwinReportedProperties` method shall call its callback with an error if connecting fails. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_067: [** The `updateTwinReportedProperties` method shall call its callback with an error if authenticating fails. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_068: [** The `updateTwinReportedProperties` method shall call the `updateTwinReportedProperties` method on the `AmqpTwinClient` instance created by the constructor. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_069: [** The `updateTwinReportedProperties` method shall call its callback with and error if the call to `AmqpTwinClient.updateTwinReportedProperties` fails. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_070: [** The `updateTwinReportedProperties` method shall call its callback with a `null` error parameter and the result of the `AmqpTwinClient.updateTwinReportedProperties` method if it succeeds. **]**
+
+### enableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_16_071: [** The `enableTwinDesiredPropertiesUpdates` method shall connect and authenticate the transport if it is disconnected. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_072: [** The `enableTwinDesiredPropertiesUpdates` method shall call its callback with an error if connecting fails. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_073: [** The `enableTwinDesiredPropertiesUpdates` method shall call its callback with an error if authenticating fails. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_074: [** The `enableTwinDesiredPropertiesUpdates` method shall call the `enableTwinDesiredPropertiesUpdates` method on the `AmqpTwinClient` instance created by the constructor. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_075: [** The `enableTwinDesiredPropertiesUpdates` method shall call its callback with and error if the call to `AmqpTwinClient.enableTwinDesiredPropertiesUpdates` fails. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_076: [** The `enableTwinDesiredPropertiesUpdates` method shall call its callback with no arguments if the call to `AmqpTwinClient.enableTwinDesiredPropertiesUpdates` succeeds. **]**
+
+### disableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_16_077: [** The `disableTwinDesiredPropertiesUpdates` method shall call the `disableTwinDesiredPropertiesUpdates` method on the `AmqpTwinClient` instance created by the constructor. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_078: [** The `disableTwinDesiredPropertiesUpdates` method shall call its callback with and error if the call to `AmqpTwinClient.disableTwinDesiredPropertiesUpdates` fails. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_079: [** The `disableTwinDesiredPropertiesUpdates` method shall call its callback no arguments if the call to `AmqpTwinClient.disableTwinDesiredPropertiesUpdates` succeeds. **]**

--- a/device/transport/amqp/package.json
+++ b/device/transport/amqp/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 94 --branches 84  --lines 95 --functions 93"
+    "check-cover": "istanbul check-coverage --statements 93 --branches 83  --lines 94 --functions 91"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -8,7 +8,7 @@ import * as dbg from 'debug';
 const debug = dbg('azure-iot-device-amqp:Amqp');
 import { EventEmitter } from 'events';
 
-import { DeviceMethodResponse, Client } from 'azure-iot-device';
+import { DeviceMethodResponse, Client, TwinProperties } from 'azure-iot-device';
 import { Amqp as BaseAmqpClient, translateError, AmqpMessage, SenderLink, ReceiverLink } from 'azure-iot-amqp-base';
 import { endpoint, SharedAccessSignature, errors, results, Message, X509, AuthenticationProvider, AuthenticationType } from 'azure-iot-common';
 import { AmqpDeviceMethodClient } from './amqp_device_method_client';
@@ -113,6 +113,8 @@ export class Amqp extends EventEmitter implements Client.Transport {
       this.emit('error', twinError);
     });
 
+    this._twinClient.on('twinDesiredPropertiesUpdate', (patch) => this.emit('twinDesiredPropertiesUpdate', patch));
+
     /*Codes_SRS_NODE_DEVICE_AMQP_16_034: [Any `error` event received on the C2D link shall trigger the emission of an `error` event by the transport, with an argument that is a `C2DDetachedError` object with the `innerError` property set to that error.]*/
     this._c2dErrorListener = (err) => {
       debug('Error on the C2D link: ' + err.toString());
@@ -166,26 +168,43 @@ export class Amqp extends EventEmitter implements Client.Transport {
             // nothing to do here: the SAS has been updated in the config object.
             callback(null, new results.SharedAccessSignatureUpdated(false));
           },
-          getTwinReceiver: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_027: [** The `getTwinReceiver` method shall connect and authenticate the AMQP connection if necessary.]*/
+          getTwin: (callback)  => {
+            /*Codes_SRS_NODE_DEVICE_AMQP_16_059: [The `getTwin` method shall connect and authenticate the transport if it is disconnected.]*/
             this._fsm.handle('connect', (err, result) => {
               if (err) {
-                /*Tests_SRS_NODE_DEVICE_AMQP_16_028: [The `getTwinReceiver` method shall call the `done` callback with the corresponding error if the transport fails connect or authenticate the AMQP connection.]*/
+                /*Codes_SRS_NODE_DEVICE_AMQP_16_060: [The `getTwin` method shall call its callback with an error if connecting fails.]*/
+                /*Codes_SRS_NODE_DEVICE_AMQP_16_061: [The `getTwin` method shall call its callback with an error if authenticating fails.]*/
                 callback(err);
               } else {
-                this._fsm.handle('getTwinReceiver', callback);
+                this._fsm.handle('getTwin', callback);
               }
             });
           },
-          sendTwinRequest: (method, resource, properties, body, sendTwinRequestCallback) => {
+          updateTwinReportedProperties: (patch, callback)  => {
+            /*Codes_SRS_NODE_DEVICE_AMQP_16_065: [The `updateTwinReportedProperties` method shall connect and authenticate the transport if it is disconnected.]*/
             this._fsm.handle('connect', (err, result) => {
               if (err) {
-                sendTwinRequestCallback(err);
+                /*Codes_SRS_NODE_DEVICE_AMQP_16_066: [The `updateTwinReportedProperties` method shall call its callback with an error if connecting fails.]*/
+                /*Codes_SRS_NODE_DEVICE_AMQP_16_067: [The `updateTwinReportedProperties` method shall call its callback with an error if authenticating fails.]*/
+                callback(err);
               } else {
-                this._fsm.handle('sendTwinRequest', method, resource, properties, body, sendTwinRequestCallback);
+                this._fsm.handle('updateTwinReportedProperties', patch, callback);
               }
             });
           },
+          enableTwinDesiredPropertiesUpdates:  (callback)  => {
+           /*Codes_SRS_NODE_DEVICE_AMQP_16_071: [The `enableTwinDesiredPropertiesUpdates` method shall connect and authenticate the transport if it is disconnected.]*/
+            this._fsm.handle('connect', (err, result) => {
+              if (err) {
+                /*Codes_SRS_NODE_DEVICE_AMQP_16_072: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with an error if connecting fails.]*/
+                /*Codes_SRS_NODE_DEVICE_AMQP_16_073: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with an error if authenticating fails.]*/
+                callback(err);
+              } else {
+                this._fsm.handle('enableTwinDesiredPropertiesUpdates', callback);
+              }
+            });
+          },
+          disableTwinDesiredPropertiesUpdates: (callback) => callback(),
           /*Codes_SRS_NODE_DEVICE_AMQP_16_031: [The `enableC2D` method shall connect and authenticate the transport if it is disconnected.]*/
           enableC2D: (callback) => {
             this._fsm.handle('connect', (err, result) => {
@@ -215,22 +234,6 @@ export class Amqp extends EventEmitter implements Client.Transport {
           },
           /*Codes_SRS_NODE_DEVICE_AMQP_16_044: [The `disableMethods` method shall call its `callback` immediately if the transport is already disconnected.]*/
           disableMethods: (callback) => {
-            // if we are disconnected the C2D link is already detached.
-            callback();
-          },
-          /*Codes_SRS_NODE_DEVICE_AMQP_16_045: [The `enableTwin` method shall connect and authenticate the transport if it is disconnected.]*/
-          enableTwin: (callback) => {
-            this._fsm.handle('connect', (err, result) => {
-              if (err) {
-                /*Codes_SRS_NODE_DEVICE_AMQP_16_047: [The `enableTwin` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach twin links.]*/
-                callback(err);
-              } else {
-                this._fsm.handle('enableTwin', callback);
-              }
-            });
-          },
-          /*Codes_SRS_NODE_DEVICE_AMQP_16_051: [The `disableTwin` method shall call its `callback` immediately if the transport is already disconnected.]*/
-          disableTwin: (callback) => {
             // if we are disconnected the C2D link is already detached.
             callback();
           }
@@ -337,13 +340,22 @@ export class Amqp extends EventEmitter implements Client.Transport {
               }
             });
           },
-          getTwinReceiver: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_026: [** The `getTwinReceiver` method shall call the `done` callback with a `null` error argument and the `AmqpTwinClient` instance currently in use.]*/
-            callback(null, this._twinClient);
-          },
-          sendTwinRequest: (method, resource, properties, body, sendTwinRequestCallback) => {
-            this._twinClient.sendTwinRequest(method, resource, properties, body, sendTwinRequestCallback);
-          },
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_062: [The `getTwin` method shall call the `getTwin` method on the `AmqpTwinClient` instance created by the constructor.]*/
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_063: [The `getTwin` method shall call its callback with and error if the call to `AmqpTwinClient.getTwin` fails.]*/
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_064: [The `getTwin` method shall call its callback with a `null` error parameter and the result of the `AmqpTwinClient.getTwin` method if it succeeds.]*/
+          getTwin: (callback) => this._twinClient.getTwin(handleResult('could not get twin', callback)),
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_068: [The `updateTwinReportedProperties` method shall call the `updateTwinReportedProperties` method on the `AmqpTwinClient` instance created by the constructor.]*/
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_069: [The `updateTwinReportedProperties` method shall call its callback with and error if the call to `AmqpTwinClient.updateTwinReportedProperties` fails.]*/
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_070: [The `updateTwinReportedProperties` method shall call its callback with a `null` error parameter and the result of the `AmqpTwinClient.updateTwinReportedProperties` method if it succeeds.]*/
+          updateTwinReportedProperties: (patch, callback) => this._twinClient.updateTwinReportedProperties(patch, handleResult('could not update twin reported properties', callback)),
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_074: [The `enableTwinDesiredPropertiesUpdates` method shall call the `enableTwinDesiredPropertiesUpdates` method on the `AmqpTwinClient` instance created by the constructor.]*/
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_075: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with and error if the call to `AmqpTwinClient.enableTwinDesiredPropertiesUpdates` fails.]*/
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_076: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with no arguments if the call to `AmqpTwinClient.enableTwinDesiredPropertiesUpdates` succeeds.]*/
+          enableTwinDesiredPropertiesUpdates: (callback) => this._twinClient.enableTwinDesiredPropertiesUpdates(handleResult('could not enable twin desired properties updates', callback)),
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_077: [The `disableTwinDesiredPropertiesUpdates` method shall call the `disableTwinDesiredPropertiesUpdates` method on the `AmqpTwinClient` instance created by the constructor.]*/
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_078: [The `disableTwinDesiredPropertiesUpdates` method shall call its callback with and error if the call to `AmqpTwinClient.disableTwinDesiredPropertiesUpdates` fails.]*/
+          /*Codes_SRS_NODE_DEVICE_AMQP_16_079: [The `disableTwinDesiredPropertiesUpdates` method shall call its callback no arguments if the call to `AmqpTwinClient.disableTwinDesiredPropertiesUpdates` succeeds.]*/
+          disableTwinDesiredPropertiesUpdates: (callback) => this._twinClient.disableTwinDesiredPropertiesUpdates(handleResult('could not disable twin desired properties updates', callback)),
           enableC2D: (callback) => {
             debug('attaching C2D link');
             this._amqp.attachReceiverLink(this._c2dEndpoint, null, (err, receiverLink) => {
@@ -375,16 +387,6 @@ export class Amqp extends EventEmitter implements Client.Transport {
             /*Codes_SRS_NODE_DEVICE_AMQP_16_042: [The `disableMethods` method shall call `detach` on the device method links and call its callback when these are successfully detached.]*/
             /*Codes_SRS_NODE_DEVICE_AMQP_16_043: [The `disableMethods` method shall call its `callback` with an `Error` if it fails to detach the device method links.]*/
             this._deviceMethodClient.detach(callback);
-          },
-          enableTwin: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_046: [The `enableTwin` method shall attach the twin links and call its `callback` once these are successfully attached.]*/
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_047: [The `enableTwin` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach twin links.]*/
-            this._twinClient.attach(callback);
-          },
-          disableTwin: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_049: [The `disableTwin` method shall call `detach` on the twin links and call its callback when these are successfully detached.]*/
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_050: [The `disableTwin` method shall call its `callback` with an `Error` if it fails to detach the twin links.]*/
-            this._twinClient.detach(callback);
           }
         },
         disconnecting: {
@@ -409,6 +411,19 @@ export class Amqp extends EventEmitter implements Client.Transport {
                     callback();
                   });
                 }
+              },
+              (callback) => {
+                this._twinClient.detach((twinDetachError) => {
+                  if (twinDetachError) {
+                    debug('error detaching twin links: ' + twinDetachError.toString());
+                    if (!finalError) {
+                      finalError = translateError('error while detaching twin links', twinDetachError);
+                    }
+                  } else {
+                    debug('device twin links detached');
+                  }
+                  callback();
+                });
               },
               (callback) => {
                 if (this._d2cLink) {
@@ -664,42 +679,33 @@ export class Amqp extends EventEmitter implements Client.Transport {
 
   /**
    * @private
-   * @method          module:azure-iot-device-amqp.Amqp#sendTwinRequest
-   * @description     Send a device-twin specific messager to the IoT Hub instance
+   * Gets the Twin for the connected device.
    *
-   * @param {String}        method    name of the method to invoke ('PUSH', 'PATCH', etc)
-   * @param {String}        resource  name of the resource to act on (e.g. '/properties/reported/') with beginning and ending slashes
-   * @param {Object}        properties  object containing name value pairs for request properties (e.g. { 'rid' : 10, 'index' : 17 })
-   * @param {String}        body  body of request
-   * @param {Function}      done  the callback to be invoked when this function completes.
-   *
-   * @throws {ReferenceError}   One of the required parameters is falsy
-   * @throws {ArgumentError}  One of the parameters is an incorrect type
+   * @param callback called when the transport has a twin or encountered and error trying to retrieve it.
    */
-  sendTwinRequest(method: string, resource: string, properties: { [key: string]: string }, body: any, done?: (err?: Error, result?: results.MessageEnqueued) => void): void {
-    this._fsm.handle('sendTwinRequest', method, resource, properties, body, (err) => {
-      if (done) {
-        done(err);
-      }
-    });
+  getTwin(callback: (err?: Error, twin?: TwinProperties) => void): void {
+    this._fsm.handle('getTwin', callback);
   }
 
   /**
    * @private
-   * @method          module:azure-iot-device-mqtt.Amqp#getTwinReceiver
-   * @description     Get a receiver object that handles C2D device-twin traffic
-   *
-   * @param {Function}  done      the callback to be invoked when this function completes.
-   *
-   * @throws {ReferenceError}   One of the required parameters is falsy
    */
-  getTwinReceiver(done: (err?: Error, receiver?: AmqpTwinClient) => void): void {
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_033: [The `getTwinReceiver` method shall throw an `ReferenceError` if done is falsy] */
-    if (!done) {
-      throw new ReferenceError('required parameter is missing');
-    }
+  updateTwinReportedProperties(patch: any, callback: (err?: Error) => void): void {
+    this._fsm.handle('updateTwinReportedProperties', patch, callback);
+  }
 
-    this._fsm.handle('getTwinReceiver', done);
+  /**
+   * @private
+   */
+  enableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void {
+    this._fsm.handle('enableTwinDesiredPropertiesUpdates', callback);
+  }
+
+  /**
+   * @private
+   */
+  disableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void {
+    this._fsm.handle('disableTwinDesiredPropertiesUpdates', callback);
   }
 
   /**
@@ -728,20 +734,6 @@ export class Amqp extends EventEmitter implements Client.Transport {
    */
   disableMethods(callback: (err?: Error) => void): void {
     this._fsm.handle('disableMethods', callback);
-  }
-
-  /**
-   * @private
-   */
-  enableTwin(callback: (err?: Error) => void): void {
-    this._fsm.handle('enableTwin', callback);
-  }
-
-  /**
-   * @private
-   */
-  disableTwin(callback: (err?: Error) => void): void {
-    this._fsm.handle('disableTwin', callback);
   }
 
   protected _getConnectionUri(host: string): string {

--- a/device/transport/amqp/src/amqp_twin_client.ts
+++ b/device/transport/amqp/src/amqp_twin_client.ts
@@ -6,102 +6,134 @@
 import { EventEmitter } from 'events';
 import machina = require('machina');
 
-import { endpoint, errors, results, Message, AuthenticationProvider } from 'azure-iot-common';
-import { Amqp as BaseAmqpClient, translateError, AmqpMessage } from 'azure-iot-amqp-base';
+import { endpoint, Message, AuthenticationProvider } from 'azure-iot-common';
+import { Amqp as BaseAmqpClient, AmqpMessage, SenderLink, ReceiverLink } from 'azure-iot-amqp-base';
+import { TwinProperties } from 'azure-iot-device';
 
 import * as uuid from 'uuid';
 import * as dbg from 'debug';
 const debug = dbg('azure-iot-device-amqp:AmqpTwinClient');
 
-const responseTopic = '$iothub/twin/res';
+enum TwinMethod {
+  GET = 'GET',
+  PATCH = 'PATCH',
+  PUT = 'PUT',
+  DELETE = 'DELETE'
+}
+
 
 /**
  * @private
  * @class        module:azure-iot-device-amqp.AmqpTwinClient
- * @classdesc    Acts as a receiver for device-twin traffic
+ * @classdesc    Acts as a client for device-twin traffic
  *
- * @param {Object} config   configuration object
- * @fires AmqpTwinClient#subscribed   an response or post event has been set up for listening.
- * @fires AmqpTwinClient#error    an error has occurred
- * @fires AmqpTwinClient#response   a response message has been received from the service
- * @fires AmqpTwinClient#post a post message has been received from the service
- * @throws {ReferenceError} If client parameter is falsy.
+ * @param {Object} config                        configuration object
+ * @fires AmqpTwinClient#error                   an error has occurred
+ * @fires AmqpTwinClient#desiredPropertyUpdate   a desired property has been updated
+ * @throws {ReferenceError}                      If client parameter is falsy.
  *
  */
 
 /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_005: [The `AmqpTwinClient` shall inherit from the `EventEmitter` class.] */
 export class AmqpTwinClient extends EventEmitter {
-  static errorEvent: string = 'error';
-  static responseEvent: string = 'response';
-  static postEvent: string = 'post';
-  static subscribedEvent: string = 'subscribed';
-
   private _client: BaseAmqpClient;
   private _authenticationProvider: AuthenticationProvider;
-  private _boundMessageHandler: Function;
   private _endpoint: string;
-  private _upstreamAmqpLink: any;
-  private _downstreamAmqpLink: any;
+  private _senderLink: SenderLink;
+  private _receiverLink: ReceiverLink;
   private _fsm: any;
-  private _internalOperations: { [key: string]: () => void };
-  private _eventQueue: any[];
-  private _eventQueueError: Error;
+  // need type for twin properties
+  private _pendingTwinRequests: { [key: string]: (err: Error, twinProperties?: any) => void };
+
+  private _messageHandler: (message: Message) => void;
+  private _errorHandler: (err: Error) => void;
 
   constructor(authenticationProvider: AuthenticationProvider, client: any) {
     super();
     this._client = client;
     this._authenticationProvider = authenticationProvider;
-    this._internalOperations = {};
-    this._upstreamAmqpLink = null;
-    this._downstreamAmqpLink = null;
-    this._eventQueue = [];
-    this._eventQueueError = null;
+    this._senderLink = null;
+    this._receiverLink = null;
+    this._pendingTwinRequests = {};
+
+    this._messageHandler = (message: Message): void => {
+      //
+      // The ONLY time we should see a message on the receiver link without a correlationId is if the message is a desired property delta update.
+      //
+      const correlationId: string = message.correlationId;
+      if (correlationId) {
+        this._onResponseMessage(message);
+      } else if (message.hasOwnProperty('data')) {
+        this._onDesiredPropertyDelta(message);
+      } else {
+        //
+        // Can't be any message we know what to do with.  Just drop it on the floor.
+        //
+        debug('malformed response message received from service: ' + JSON.stringify(message));
+      }
+    };
+
+    this._errorHandler = (err: Error): void => this._fsm.handle('handleLinkError', err);
 
     this._fsm = new machina.Fsm({
-      namespace: 'amqp-twin-receiver',
+      namespace: 'amqp-twin-client',
       initialState: 'detached',
       states: {
-        'detached': {
+        detached: {
           _onEnter: (err, detachCallback) => {
-            let headEvent: any[];
-            while (headEvent = this._eventQueue.shift()) {
-              if (headEvent.shift() === 'actual_sendTwinRequest') {
-                this._rundown_sendTwinRequest.apply(this, headEvent);
+            if (detachCallback) {
+                detachCallback(err);
+            } else {
+              if (err) {
+                this.emit('error', err);
               }
             }
-            this._eventQueueError = null;
-            if (detachCallback) {
-              /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_005: [The `detach` method shall detach the links and call its `callback` with no arguments if the links are successfully detached.]*/
-              /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_002: [The `attach` method shall call its `callback` with an `Error` if attaching either link fails.]*/
-              /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_006: [The `detach` method shall call its `callback` with an `Error` if detaching either of the links fail.]*/
-              // TODO: refactoring needed: requirement not met for now...
-              detachCallback(err);
-            }
           },
-          handleNewListener: (eventName) => {
-            if ((eventName === AmqpTwinClient.responseEvent) || (eventName === AmqpTwinClient.postEvent)) {
-              this._appendEventQueue();
-              this._fsm.transition('attaching');
-            }
+          getTwin: (callback) => {
+            /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_007: [The `getTwin` method shall attach the sender link if it's not already attached.]*/
+            /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_009: [THe `getTwin` method shall attach the receiver link if it's not already attached.]*/
+            this._fsm.transition('attaching', (err) => {
+              if (err) {
+                /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_008: [If attaching the sender link fails, the `getTwin` method shall call its callback with the error that caused the failure.]*/
+                /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_010: [If attaching the receiver link fails, the `getTwin` method shall call its callback with the error that caused the failure.]*/
+                callback(err);
+              } else {
+                this._fsm.handle('getTwin', callback);
+              }
+            });
           },
-          sendTwinRequest: () => {
-            this._appendEventQueue();
-            this._fsm.transition('attaching');
+          updateTwinReportedProperties: (patch, callback) => {
+            /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_015: [The `updateTwinReportedProperties` method shall attach the sender link if it's not already attached.]*/
+            /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_017: [THe `updateTwinReportedProperties` method shall attach the receiver link if it's not already attached.]*/
+            this._fsm.transition('attaching', (err) => {
+              if (err) {
+                /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_016: [If attaching the sender link fails, the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure.]*/
+                /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_018: [If attaching the receiver link fails, the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure.]*/
+                callback(err);
+              } else {
+                this._fsm.handle('updateTwinReportedProperties', patch, callback);
+              }
+            });
           },
-          handleErrorEmit: (err: Error) => {
-            debug('_handleError: error is: ' + err);
-            this.emit(AmqpTwinClient.errorEvent, translateError('received an error from the amqp transport: ', err));
+          enableTwinDesiredPropertiesUpdates: (callback) => {
+            /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_023: [The `enableTwinDesiredPropertiesUpdates` method shall attach the sender link if it's not already attached.]*/
+            /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_025: [The `enableTwinDesiredPropertiesUpdates` method shall attach the receiver link if it's not already attached.]*/
+            this._fsm.transition('attaching', (err) => {
+              if (err) {
+                /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_024: [If attaching the sender link fails, the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
+                /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_026: [If attaching the receiver link fails, the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
+                callback(err);
+              } else {
+                this._fsm.handle('enableTwinDesiredPropertiesUpdates', callback);
+              }
+            });
           },
-          attach: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_001: [The `attach` method shall attach both sender and receiver links and calls its `callback` with no argument if successful.]*/
-            this._fsm.transition('attaching', callback);
-          },
-          detach: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_004: [The `detach` method shall call its `callback` immediately if the links are already detached.]*/
-            callback();
-          }
+          /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_031: [The `disableTwinDesiredPropertiesUpdates` method shall call its callback immediately and with no arguments if the links are detached.]*/
+          disableTwinDesiredPropertiesUpdates: (callback) => callback(),
+          /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_004: [The `detach` method shall call its `callback` immediately if the links are already detached.]*/
+          detach: (callback) => callback()
         },
-        'attaching': {
+        attaching: {
           _onEnter: (attachCallback) => {
             /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_007: [The `attach` method shall call the `getDeviceCredentials` method on the `authenticationProvider` object passed as an argument to the constructor to retrieve the device id.]*/
             this._authenticationProvider.getDeviceCredentials((err, credentials) => {
@@ -118,16 +150,17 @@ export class AmqpTwinClient extends EventEmitter {
                   this._client.attachReceiverLink( this._endpoint, this._generateTwinLinkProperties(linkCorrelationId), (receiverLinkError?: Error, receiverTransportObject?: any): void => {
                     if (receiverLinkError) {
                       /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_022: [If an error occurs on establishing the upstream or downstream link then the `error` event shall be emitted.] */
-                      this._fsm.handle('handleErrorEmit', receiverLinkError);
+                      this._fsm.transition('detached', receiverLinkError, attachCallback);
                     } else {
-                      this._downstreamAmqpLink = receiverTransportObject;
-                      this._downstreamAmqpLink.on('error', this._handleError.bind(this));
+                      this._receiverLink = receiverTransportObject;
+                      this._receiverLink.on('message', this._messageHandler);
+                      this._receiverLink.on('error', this._errorHandler);
                       this._client.attachSenderLink( this._endpoint, this._generateTwinLinkProperties(linkCorrelationId), (senderLinkError?: Error, senderTransportObject?: any): void => {
                         if (senderLinkError) {
-                          this._fsm.handle('handleErrorEmit', senderLinkError);
+                          this._fsm.transition('detached', senderLinkError, attachCallback);
                         } else {
-                          this._upstreamAmqpLink = senderTransportObject;
-                          this._upstreamAmqpLink.on('error', this._handleError.bind(this));
+                          this._senderLink = senderTransportObject;
+                          this._senderLink.on('error', this._errorHandler);
                           this._fsm.transition('attached', attachCallback);
                         }
                       });
@@ -136,163 +169,95 @@ export class AmqpTwinClient extends EventEmitter {
               }
             });
           },
-          handleErrorEmit: () => {
-            this._fsm.deferUntilTransition('detached');
-            this._fsm.transition('detaching');
-          },
-          handleNewListener: () => {
-            this._appendEventQueue();
-          },
-          handleRemoveListener: () => {
-            this._appendEventQueue();
-          },
-          sendTwinRequest: () => {
-            this._appendEventQueue();
-          },
+          handleLinkError: (err, callback) => this._fsm.transition('detaching', err, callback),
+          detach: (callback) => this._fsm.transition('detaching', null, callback),
           '*': () => this._fsm.deferUntilTransition()
         },
-        'attached': {
-          _onEnter: (attachCallback) => {
-            this._downstreamAmqpLink.on('message', this._boundMessageHandler);
-            this._handleHeadOfEventQueue();
-            if (attachCallback) {
-              /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_001: [The `attach` method shall attach both sender and receiver links and calls its `callback` with no argument if successful.]*/
-              attachCallback();
-            }
-          },
-          actual_handleNewListener: (eventName) => {
-            if (eventName === AmqpTwinClient.responseEvent) {
-              /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_011: [** Upon successfully establishing the upstream and downstream links the `subscribed` event shall be emitted from the twin receiver, with an argument object of {eventName: "response", transportObject: <object>}.] */
-              this.emit(AmqpTwinClient.subscribedEvent, { 'eventName' : AmqpTwinClient.responseEvent, 'transportObject' : this._upstreamAmqpLink });
-            } else if (eventName === AmqpTwinClient.postEvent) {
-              //
-              // We need to send a PUT request upstream to enable notification of desired property changes
-              // from the cloud. Then we have to wait for the (hopefully) successful response to this request.
-              //
-              // Only at this point can we emit an successful subscribe to the agnostic twin code that is utilizing this receiver.
-              //
-              const correlationId = uuid.v4().toString();
-              /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_013: [Upon receiving a successful response message with the correlationId of the `PUT`, the `subscribed` event shall be emitted from the twin receiver, with an argument object of {eventName: "post", transportObject: <object>}.] */
-              this._internalOperations[correlationId] = () => {
-                this.emit(AmqpTwinClient.subscribedEvent, { 'eventName' : AmqpTwinClient.postEvent, 'transportObject' : this._upstreamAmqpLink });
-              };
-              /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_019: [Upon successfully establishing the upstream and downstream links, a `PUT` request shall be sent on the upstream link with a correlationId set in the properties of the amqp message.] */
-              this._sendTwinRequest('PUT', '/notifications/twin/properties/desired', { $rid: correlationId }, ' ');
-            }
-            this._handleHeadOfEventQueue();
-          },
-          actual_handleRemoveListener: (eventName) => {
-            if ((eventName === AmqpTwinClient.postEvent) && EventEmitter.listenerCount(this, AmqpTwinClient.postEvent) === 0) {
-              /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_021: [When there is no more listeners for the `post` event, a `DELETE` request shall be sent on the upstream link with a correlationId set in the properties of the amqp message.] */
-              const correlationId = uuid.v4().toString();
-              this._internalOperations[correlationId] = () => {
-                debug('Turned off desired property notification');
-              };
-              this._sendTwinRequest('DELETE', '/notifications/twin/properties/desired', { $rid: correlationId }, ' ');
-            }
-            if ((EventEmitter.listenerCount(this, AmqpTwinClient.postEvent) + EventEmitter.listenerCount(this, AmqpTwinClient.responseEvent)) === 0) {
-              /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_014: [When there are no more listeners for the `response` AND the `post` event, the upstream and downstream amqp links shall be closed via calls to `detachReceiverLink` and `detachSenderLink`.] */
-              this._fsm.transition('detaching');
-            } else {
-              this._handleHeadOfEventQueue();
-            }
-          },
-          actual_sendTwinRequest: (method, resource, properties, body, done) => {
-            this._sendTwinRequest(method, resource, properties, body, done);
-            this._handleHeadOfEventQueue();
-          },
-          handleNewListener: () => {
-            this._AppendOrHandleEvent();
-          },
-          handleRemoveListener: () => {
-            this._AppendOrHandleEvent();
-          },
-          sendTwinRequest: () => {
-            this._AppendOrHandleEvent();
-          },
-          handleErrorEmit: () => {
-            this._fsm.deferUntilTransition('detached');
-            this._fsm.transition('detaching');
-          },
-          attach: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_003: [The `attach` method shall call its `callback` immediately if the links are already attached.]*/
+        attached: {
+          _onEnter: (callback) => {
             callback();
           },
-          detach: (callback) => {
-            this._fsm.transition('detaching', callback);
+          handleLinkError: (err) => {
+            this._fsm.transition('detaching', err);
           },
-          _onExit: () => {
-            this._downstreamAmqpLink.removeListener('message', this._boundMessageHandler);
-          }
+          /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_011: [** The `getTwin` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+          - `operation` annotation set to `GET`.
+          - `resource` annotation set to `undefined`
+          - `correlationId` property set to a random integer
+          - `body` set to ` `.]*/
+          getTwin: (callback) => this._sendTwinRequest(TwinMethod.GET, undefined, ' ', callback),
+          /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_019: [The `updateTwinReportedProperties` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+          - `operation` annotation set to `PATCH`.
+          - `resource` annotation set to `/properties/reported`
+          - `correlationId` property set to a random integer
+          - `body` set to the stringified patch object.]*/
+          updateTwinReportedProperties: (patch, callback) => this._sendTwinRequest(TwinMethod.PATCH, '/properties/reported', JSON.stringify(patch), callback),
+          /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_027: [The `enableTwinDesiredPropertiesUpdates` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+          - `operation` annotation set to `PUT`.
+          - `resource` annotation set to `/notifications/twin/properties/desired`
+          - `correlationId` property set to a random integer
+          - `body` set to `undefined`.]*/
+          enableTwinDesiredPropertiesUpdates: (callback) => this._sendTwinRequest(TwinMethod.PUT, '/notifications/twin/properties/desired', ' ', callback),
+          /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_032: [The `disableTwinDesiredPropertiesUpdates` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+          - `operation` annotation set to `DELETE`.
+          - `resource` annotation set to `/notifications/twin/properties/desired`
+          - `correlationId` property set to a random integer
+          - `body` set to `undefined`.]*/
+          disableTwinDesiredPropertiesUpdates: (callback) => this._sendTwinRequest(TwinMethod.DELETE, '/notifications/twin/properties/desired', ' ', callback),
+          detach: (callback) => this._fsm.transition('detaching', null, callback)
         },
-        'detaching': {
-          _onEnter: (detachCallback) => {
-            this._client.detachSenderLink( this._endpoint, (detachSenderError: Error, result?: any) => {
+        detaching: {
+          _onEnter: (err, detachCallback) => {
+            const senderLink = this._senderLink;
+            const receiverLink = this._receiverLink;
+            /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_005: [The `detach` method shall detach the links and call its `callback` with no arguments if the links are successfully detached.]*/
+            this._client.detachSenderLink(this._endpoint, (detachSenderError: Error, result?: any) => {
+              senderLink.removeListener('error', this._errorHandler);
               if (detachSenderError) {
                 debug('we received an error for the detach of the upstream link during the disconnect.  Moving on to the downstream link.');
               }
               this._client.detachReceiverLink(this._endpoint,  (detachReceiverError: Error, result?: any) => {
+                receiverLink.removeListener('message', this._messageHandler);
+                receiverLink.removeListener('error', this._errorHandler);
                 if (detachReceiverError) {
                   debug('we received an error for the detach of the downstream link during the disconnect.');
                 }
-                let possibleError = detachSenderError || detachReceiverError;
-                if (possibleError) {
-                  this._fsm.handle('handleErrorEmit', possibleError);
-                }
-                this._fsm.transition('detached', null, detachCallback);
+                /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_006: [The `detach` method shall call its `callback` with an `Error` if detaching either of the links fail.]*/
+                let possibleError = err || detachSenderError || detachReceiverError;
+                this._fsm.transition('detached', possibleError, detachCallback);
               });
             });
           },
-          handleErrorEmit: () => {
-            this._fsm.deferUntilTransition('detached');
-          },
-          handleNewListener: () => {
-            this._appendEventQueue();
-          },
-          handleRemoveListener: () => {
-            this._appendEventQueue();
-          },
-          sendTwinRequest: () => {
-            this._appendEventQueue();
-          }
+          '*': () => this._fsm.deferUntilTransition()
         }
       }
     });
+  }
 
-    this._fsm.on('transition', (transition) => {
-      debug(transition.fromState + ' -> ' + transition.toState + ' (action:' + transition.action + ')');
-    });
+  getTwin(callback: (err: Error, twin?: TwinProperties) => void): void {
+    this._fsm.handle('getTwin', callback);
+  }
 
-    this.on('newListener', this._handleNewListener.bind(this));
-    this.on('removeListener', this._handleRemoveListener.bind(this));
-    this._boundMessageHandler = this._onAmqpMessage.bind(this); // need to save this so that calls to add & remove listeners can be matched by the EventEmitter.
+  updateTwinReportedProperties(patch: any, callback: (err?: Error) => void): void {
+    this._fsm.handle('updateTwinReportedProperties', patch, callback);
+  }
 
+  enableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void {
+    this._fsm.handle('enableTwinDesiredPropertiesUpdates', callback);
+  }
+
+  disableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void {
+    this._fsm.handle('disableTwinDesiredPropertiesUpdates', callback);
   }
 
   /**
-   * @method          module:azure-iot-device-amqp.Amqp#sendTwinRequest
-   * @description     Send a device-twin specific message to the IoT Hub instance
-   *
-   * @param {String}        method    name of the method to invoke ('PUSH', 'PATCH', etc)
-   * @param {String}        resource  name of the resource to act on (e.g. '/properties/reported/') with beginning and ending slashes
-   * @param {Object}        properties  object containing name value pairs for request properties (e.g. { 'rid' : 10, 'index' : 17 })
-   * @param {String}        body  body of request
-   * @param {Function}      done  the callback to be invoked when this function completes.
-   *
-   * @throws {ReferenceError}   One of the required parameters is falsy
-   * @throws {ArgumentError}  One of the parameters is an incorrect type
+   * Necessary for the client to be able to properly detach twin links
+   * attach() isn't necessary because it's done by the FSM automatically when one of the APIs is called.
    */
-  sendTwinRequest(method: string, resource: string, properties: { [key: string]: string }, body: any, done?: (err?: Error, result?: any) => void): void {
-    this._fsm.handle('sendTwinRequest', method, resource, properties, body, done);
-  }
-
-  attach(callback: (err: Error) => void): void {
-    this._fsm.handle('attach', callback);
-  }
-
-  detach(callback: (err: Error) => void): void {
+  detach(callback: (err?: Error) => void): void {
     this._fsm.handle('detach', callback);
   }
+
 
   private _generateTwinLinkProperties( correlationId: string): any {
     /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_010: [** The link options argument for attachSenderLink shall be:
@@ -326,195 +291,63 @@ export class AmqpTwinClient extends EventEmitter {
     };
   }
 
-  private _handleNewListener(eventName: string): void {
-    this._fsm.handle('handleNewListener', eventName);
-  }
-
-  private _handleRemoveListener(eventName: string): void {
-    this._fsm.handle('handleRemoveListener', eventName);
-  }
-
-  private _onAmqpMessage(message: Message): void {
-    //
-    // The ONLY time we should see a message on the downstream link without a correlationId is if the message is a desired property delta update.
-    //
-    const correlationId: string = message.correlationId;
-    if (correlationId) {
-      this._onResponseMessage(message);
-    } else if (message.hasOwnProperty('data')) {
-      this._onDesiredPropertyDelta(message);
-    } else {
-      //
-      // Can't be any message we know what to do with.  Just drop it on the floor.
-      //
-      debug('malformed response message received from service: ' + JSON.stringify(message));
-    }
-  }
-
   private _onResponseMessage(message: Message): void {
     debug('onResponseMessage: The downstream message is: ' + JSON.stringify(message));
-    if (this._internalOperations[message.correlationId]) {
-      const callback = this._internalOperations[message.correlationId];
-      delete this._internalOperations[message.correlationId];
-      callback();
+    /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_013: [The `getTwin` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received.]*/
+    /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_021: [The `updateTwinReportedProperties` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received.]*/
+    /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_029: [The `enableTwinDesiredPropertiesUpdates` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received.]*/
+    /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_034: [The `disableTwinDesiredPropertiesUpdates` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received.]*/
+    if (this._pendingTwinRequests[message.correlationId]) {
+      const pendingRequestCallback = this._pendingTwinRequests[message.correlationId];
+      delete this._pendingTwinRequests[message.correlationId];
+      // TODO: Test resource property and status code?
+      let result = message.data ? JSON.parse(message.data) : undefined;
+      /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_014: [The `getTwin` method shall parse the body of the received message and call its callback with a `null` error object and the parsed object as a result.]*/
+      /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_022: [The `updateTwinReportedProperties` method shall call its callback with no argument when a response is received]*/
+      /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_030: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with no argument when a response is received]*/
+      /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_035: [The `disableTwinDesiredPropertiesUpdates` method shall call its callback with no argument when a response is received]*/
+      pendingRequestCallback(null, result);
     } else {
-      //
-      // The service sending back any response is an implied success.  Set status to 200.
-      //
-      /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_016: [When a `response` event is emitted, the parameter shall be an object which contains `status`, `requestId` and `body` members.] */
-      /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_026: [The `status` value is acquired from the amqp message status message annotation.] */
-      /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_017: [The `requestId` value is acquired from the amqp message correlationId property in the response amqp message.] */
-      /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_018: [the `body` parameter of the `response` event shall be the data of the received amqp message.] */
-      const response = {
-        'topic': responseTopic,
-        'status': message.transportObj.messageAnnotations.status,
-        '$rid': message.correlationId,
-        'body': message.data
-      };
-
-      this.emit(AmqpTwinClient.responseEvent, response);
+      debug('received a response for an unknown request: ' + JSON.stringify(message));
     }
   }
 
   private _onDesiredPropertyDelta(message: Message): void {
-    /* Codes_SRS_NODE_DEVICE_AMQP_TWIN_06_020: [If there is a listener for the `post` event, a `post` event shall be emitted for each amqp message received on the downstream link that does NOT contain a correlation id, the parameter of the emit will be is the data of the amqp message.] */
-    debug('onPostMessage: The downstream message is: ' + JSON.stringify(message));
-    this.emit(AmqpTwinClient.postEvent, message.data);
+    debug('onDesiredPropertyDelta: The message is: ' + JSON.stringify(message));
+    this.emit('twinDesiredPropertiesUpdate', JSON.parse(message.data));
   }
 
-  private _handleError(err: Error): void {
-    this._fsm.handle('handleErrorEmit', err);
-  }
-
-
-  private _safeCallback(callback: (err: Error | null, result?: any) => void, error?: Error | null, result?: any): void {
-    if (callback) {
-      process.nextTick(() => callback(error, result));
-    }
-  }
-
-  private _appendEventQueue(): void {
-    let argArray: any[] = [];
-    argArray.push('actual_' + this._fsm.currentActionArgs[0].inputType);
-    let i = 1;
-    for ( ; i <= this._fsm.currentActionArgs.length - 1 ; i++) {
-      argArray.push(this._fsm.currentActionArgs[i]);
-    }
-    this._eventQueue.push(argArray);
-  }
-
-  private _handleHeadOfEventQueue(): void {
-    let head: any[] = this._eventQueue.shift();
-    if (head) {
-      this._fsm.handle.apply(this._fsm, head);
-    }
-  }
-
-  private _AppendOrHandleEvent(): void {
-    this._appendEventQueue();
-    if (this._eventQueue.length === 1) {
-      this._handleHeadOfEventQueue();
-    }
-  }
-
-
-  private _isString(obj: any): boolean {
-    return (typeof obj === 'string');
-  }
-
-  private _isNumber(obj: any): boolean {
-    return (typeof obj === 'number');
-  }
-
-  private _isBoolean(obj: any): boolean {
-    return (typeof obj === 'boolean');
-  }
-
-  private _rundown_sendTwinRequest(method: string, resource: string, properties: { [key: string]: string }, body: any, done?: (err?: Error, result?: results.MessageEnqueued) => void): void {
-    if (!!done && (typeof done === 'function' )) {
-      done(this._eventQueueError || new Error('Link Detached'));
-    }
-  }
-
-  private _sendTwinRequest(method: string, resource: string, properties: { [key: string]: string }, body: any, done?: (err?: Error, result?: results.MessageEnqueued) => void): void {
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_012: [The `sendTwinRequest` method shall not throw `ReferenceError` if the `done` callback is falsy.] */
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_013: [The `sendTwinRequest` method shall throw an `ReferenceError` if the `method` argument is falsy.] */
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_014: [The `sendTwinRequest` method shall throw an `ReferenceError` if the `resource` argument is falsy.] */
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_015: [The `sendTwinRequest` method shall throw an `ReferenceError` if the `properties` argument is falsy.] */
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_016: [The `sendTwinRequest` method shall throw an `ReferenceError` if the `body` argument is falsy.] */
-    if (!method || !resource || !properties || !body) {
-      throw new ReferenceError('required parameter is missing');
-    }
-
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_017: [The `sendTwinRequest` method shall throw an `ArgumentError` if the `method` argument is not a string.] */
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_018: [The `sendTwinRequest` method shall throw an `ArgumentError` if the `resource` argument is not a string.] */
-    if (!this._isString(method) || !this._isString(resource)) {
-      throw new errors.ArgumentError('required string parameter is not a string');
-    }
-
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_019: [The `sendTwinRequest` method shall throw an `ArgumentError` if the `properties` argument is not a an object.] */
-    if (!(properties instanceof Object)) {
-      throw new errors.ArgumentError('required properties parameter is not an object');
-    }
-
+  private _sendTwinRequest(method: TwinMethod, resource: string, body: string, callback: (err?: Error) => void): void {
     let amqpMessage = new AmqpMessage();
-    amqpMessage.messageAnnotations = {};
-    amqpMessage.properties = {};
 
-    //
-    // Amqp requires that the resource designation NOT be terminated by a slash.  The agnostic twin client was terminating the
-    // resources with a slash which worked just dandy for MQTT.
-    //
-    // We need to cut off a terminating slash.  If we cut off a terminating slash and the length of resource is zero then simply
-    // don't specify a resource.
-    //
-    // What if the caller specifies a "//" resource?  Don't do that.
-    //
-    // So you'll note that in this case "/" sent down will be turned into an empty string.  So why not
-    // simply send down "" to begin with?  Because you can't send a falsy parameter.
-    //
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_020: [The `method` argument shall be the value of the amqp message `operation` annotation.] */
-    amqpMessage.messageAnnotations.operation = method;
-    let localResource: string = resource;
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_031: [If the `resource` argument terminates in a slash, the slash shall be removed from the annotation.] */
-    if (localResource.substr(localResource.length - 1, 1) === '/') {
-      localResource = localResource.slice(0, localResource.length - 1);
-    }
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_039: [If the `resource` argument length is zero (after terminating slash removal), the resource annotation shall not be set.] */
-    if (localResource.length > 0) {
-      /* Codes_SRS_NODE_DEVICE_AMQP_06_021: [The `resource` argument shall be the value of the amqp message `resource` annotation.] */
-      amqpMessage.messageAnnotations.resource = localResource;
+    amqpMessage.messageAnnotations = {
+      operation: method
+    };
+
+    if (resource) {
+      amqpMessage.messageAnnotations.resource = resource;
     }
 
-    Object.keys(properties).forEach((key) => {
-      /* Codes_SRS_NODE_DEVICE_AMQP_06_028: [The `sendTwinRequest` method shall throw an `ArgumentError` if any members of the `properties` object fails to serialize to a string.] */
-      if (!this._isString(properties[key]) && !this._isNumber(properties[key]) && !this._isBoolean(properties[key])) {
-        throw new errors.ArgumentError('required properties object has non-string properties');
-      }
+    const correlationId = Math.floor(Math.random() * 10000).toString();
+    amqpMessage.properties = {
+      correlationId: correlationId
+    };
 
-      /* Codes_SRS_NODE_DEVICE_AMQP_06_022: [All properties, except $rid, shall be set as the part of the properties map of the amqp message.] */
-      /* Codes_SRS_NODE_DEVICE_AMQP_06_023: [The $rid property shall be set as the `correlationId` in the properties map of the amqp message.] */
-      if (key === '$rid') {
-        amqpMessage.properties.correlationId = properties[key].toString();
-      } else {
-        amqpMessage.properties[key] = properties[key];
-      }
-    });
+    amqpMessage.body = body;
 
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_024: [The `body` shall be value of the body of the amqp message.] */
-    amqpMessage.body = body.toString();
-
-    /* Codes_SRS_NODE_DEVICE_AMQP_06_025: [The amqp message will be sent upstream to the IoT Hub via the amqp client `send`.]*/
-    this._upstreamAmqpLink.send(amqpMessage, (err, state) => {
+    this._pendingTwinRequests[correlationId] = callback;
+    this._senderLink.send(amqpMessage, (err) => {
+      /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_012: [If the `SenderLink.send` call fails the `getTwin` method shall call its callback with the error that caused the failure.]*/
+      /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_020: [If the `SenderLink.send` call fails the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure.]*/
+      /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_028: [If the `SenderLink.send` call fails the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
+      /*Codes_SRS_NODE_DEVICE_AMQP_TWIN_16_033: [If the `SenderLink.send` call fails the `disableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
       if (err) {
-        debug(' amqp-twin-receiver: Bad disposition on the amqp message send: ' + err);
-        this._safeCallback(done, translateError('Unable to send Twin message', err));
+        debug('could not get twin: ' + err.toString());
+        delete this._pendingTwinRequests[correlationId];
+        callback(err);
       } else {
-        debug(' amqp-twin-receiver: Good disposition on the amqp message send: ' + JSON.stringify(state));
-        this._safeCallback(done, null, new results.MessageEnqueued(state));
-        return null;
+        debug('getTwin request sent with correlationId: ' + correlationId);
       }
     });
   }
-
 }

--- a/device/transport/amqp/test/_amqp_test.js
+++ b/device/transport/amqp/test/_amqp_test.js
@@ -617,6 +617,29 @@ describe('Amqp', function () {
 
         });
 
+        it('disconnects the Twin client', function (testCallback) {
+          sinon.spy(transport._twinClient, 'detach');
+          transport.connect(function () {
+            transport.disconnect(function () {
+              assert.isTrue(transport._twinClient.detach.calledOnce);
+              testCallback();
+            });
+          });
+        });
+
+        it('calls the disconnect callback with an error if the Twin client encounters an error while detaching', function (testCallback) {
+          var fakeError = new Error('fake');
+          sinon.stub(transport._twinClient, 'detach').callsFake(function(callback) { callback(fakeError); });
+          transport.connect(function () {
+            transport.disconnect(function (err) {
+              assert.isTrue(transport._twinClient.detach.calledOnce);
+              assert.instanceOf(err, Error);
+              assert.strictEqual(err.amqpError, fakeError);
+              testCallback();
+            });
+          });
+        });
+
         it('disconnects the AMQP transport', function (testCallback) {
           transport.connect(function () {
             transport.disconnect(function (err, result) {
@@ -1139,377 +1162,211 @@ describe('Amqp', function () {
   });
 
   describe('Twin', function () {
-    describe('#sendTwinRequest', function () {
-      it('connects the transport if necessary', function (testCallback) {
-        transport.sendTwinRequest('POST', '/properties/reported', { temp: 42 }, {}, function () {
+    function testStateMachine(methodName, methodUnderTest) {
+      describe('#' + methodName, function () {
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_059: [The `getTwin` method shall connect and authenticate the transport if it is disconnected.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_065: [The `updateTwinReportedProperties` method shall connect and authenticate the transport if it is disconnected.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_071: [The `enableTwinDesiredPropertiesUpdates` method shall connect and authenticate the transport if it is disconnected.]*/
+        it('connects the transport if necessary', function () {
+          methodUnderTest(function () {});
           assert(fakeBaseClient.connect.calledOnce);
           assert(fakeBaseClient.initializeCBS.calledOnce);
           assert(fakeBaseClient.putToken.calledOnce);
-          testCallback();
-        });
-      });
-
-      it('waits until connected and authenticated if called while connecting', function (testCallback) {
-        var connectCallback;
-        fakeBaseClient.connect = sinon.stub().callsFake(function (uri, options, callback) {
-          connectCallback = callback;
         });
 
-        transport.connect(function () {});
-        transport.sendTwinRequest('POST', '/properties/reported', { temp: 42 }, {}, function () {
+        it('waits until connected and authenticated if called while connecting', function () {
+          var connectCallback;
+          fakeBaseClient.connect = sinon.stub().callsFake(function (uri, options, callback) {
+            connectCallback = callback;
+          });
+
+          transport.connect(function () {});
+          methodUnderTest(function () {});
+          assert(fakeBaseClient.connect.calledOnce);
+          assert(fakeBaseClient.initializeCBS.notCalled);
+          assert(fakeBaseClient.putToken.notCalled);
+          assert(sender.send.notCalled);
+          connectCallback(null, new results.Connected());
+          assert(fakeBaseClient.initializeCBS.calledOnce);
+          assert(fakeBaseClient.putToken.calledOnce);
+          assert(sender.send.calledOnce);
+        });
+
+        it('waits until connected and authenticated if called while authenticating', function () {
+          var authCallback;
+          fakeBaseClient.putToken = sinon.stub().callsFake(function (uri, options, callback) {
+            authCallback = callback;
+          });
+
+          transport.connect(function () {});
+          methodUnderTest(function () {});
           assert(fakeBaseClient.connect.calledOnce);
           assert(fakeBaseClient.initializeCBS.calledOnce);
           assert(fakeBaseClient.putToken.calledOnce);
-          testCallback();
-        });
-        connectCallback(null, new results.Connected());
-      });
-
-      it('waits until connected and authenticated if called while authenticating', function (testCallback) {
-        var authCallback;
-        fakeBaseClient.putToken = sinon.stub().callsFake(function (uri, options, callback) {
-          authCallback = callback;
+          assert(sender.send.notCalled);
+          authCallback();
+          assert(sender.send.calledOnce);
         });
 
-        transport.connect(function () {});
-        transport.sendTwinRequest('POST', '/properties/reported', { temp: 42 }, {}, function () {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert(fakeBaseClient.initializeCBS.calledOnce);
-          assert(fakeBaseClient.putToken.calledOnce);
-          testCallback();
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_060: [The `getTwin` method shall call its callback with an error if connecting fails.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_066: [The `updateTwinReportedProperties` method shall call its callback with an error if connecting fails.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_072: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with an error if connecting fails.]*/
+        it('calls its callback with an error if connecting the transport fails', function (testCallback) {
+          var testError = new Error('failed to connect');
+          fakeBaseClient.connect = sinon.stub().callsArgWith(2, testError);
+
+          methodUnderTest(function (err) {
+            assert(fakeBaseClient.connect.calledOnce);
+            assert.strictEqual(err.amqpError, testError);
+            testCallback();
+          });
         });
 
-        authCallback();
-      });
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_061: [The `getTwin` method shall call its callback with an error if authenticating fails.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_067: [The `updateTwinReportedProperties` method shall call its callback with an error if authenticating fails.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_073: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with an error if authenticating fails.]*/
+        it('calls its callback with an error if authentication fails to initialize CBS', function (testCallback) {
+          var testError = new Error('failed to authenticate');
+          fakeBaseClient.initializeCBS = sinon.stub().callsArgWith(0, testError);
 
-      it('calls its callback with an error if connecting the transport fails', function (testCallback) {
-        var testError = new Error('failed to connect');
-        fakeBaseClient.connect = sinon.stub().callsArgWith(2, testError);
-
-        transport.sendTwinRequest('POST', '/properties/reported', { temp: 42 }, {}, function (err) {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert.strictEqual(err.amqpError, testError);
-          testCallback();
-        });
-      });
-
-      it('calls its callback with an error if authentication fails to initialize CBS', function (testCallback) {
-        var testError = new Error('failed to authenticate');
-        fakeBaseClient.initializeCBS = sinon.stub().callsArgWith(0, testError);
-
-        transport.sendTwinRequest('POST', '/properties/reported', { temp: 42 }, {}, function (err) {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert(fakeBaseClient.initializeCBS.calledOnce);
-          assert.strictEqual(err.amqpError, testError);
-          testCallback();
-        });
-      });
-
-      it('calls its callback with an error if authentication fails to do a CBS putToken operation', function (testCallback) {
-        var testError = new Error('failed to authenticate');
-        fakeBaseClient.putToken = sinon.stub().callsArgWith(2, testError);
-
-        transport.sendTwinRequest('POST', '/properties/reported', { temp: 42 }, {}, function (err) {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert(fakeBaseClient.initializeCBS.calledOnce);
-          assert(fakeBaseClient.putToken.calledOnce);
-          assert.strictEqual(err.amqpError, testError);
-          testCallback();
-        });
-      });
-
-      it('calls its callback with an error if the twin client fails to send the request', function (testCallback) {
-        var testError = new Error('failed to send');
-        sender.send = sinon.stub().callsArgWith(1, testError);
-
-        transport.sendTwinRequest('POST', '/properties/reported', { temp: 42 }, {}, function (err) {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert(fakeBaseClient.initializeCBS.calledOnce);
-          assert(fakeBaseClient.putToken.calledOnce);
-          assert(fakeBaseClient.attachReceiverLink.calledOnce);
-          assert(fakeBaseClient.attachSenderLink.calledOnce);
-          assert.strictEqual(err.amqpError, testError);
-          testCallback();
-        });
-      });
-
-      it('tries to reconnect to send the message if the transport is disconnecting', function (testCallback) {
-        var disconnectCallback;
-
-        fakeBaseClient.disconnect = sinon.stub().callsFake(function (done) {
-          disconnectCallback = done;
+          methodUnderTest(function (err) {
+            assert(fakeBaseClient.connect.calledOnce);
+            assert(fakeBaseClient.initializeCBS.calledOnce);
+            assert.strictEqual(err.amqpError, testError);
+            testCallback();
+          });
         });
 
-        transport.connect(function () {
-          assert(fakeBaseClient.connect.calledOnce);
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_061: [The `getTwin` method shall call its callback with an error if authenticating fails.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_067: [The `updateTwinReportedProperties` method shall call its callback with an error if authenticating fails.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_073: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with an error if authenticating fails.]*/
+        it('calls its callback with an error if authentication fails to do a CBS putToken operation', function (testCallback) {
+          var testError = new Error('failed to authenticate');
+          fakeBaseClient.putToken = sinon.stub().callsArgWith(2, testError);
+
+          methodUnderTest(function (err) {
+            assert(fakeBaseClient.connect.calledOnce);
             assert(fakeBaseClient.initializeCBS.calledOnce);
             assert(fakeBaseClient.putToken.calledOnce);
-          transport.disconnect(function () {});
-          transport.sendTwinRequest('POST', '/properties/reported', { temp: 42 }, {}, function () {
-            assert(fakeBaseClient.connect.calledTwice);
-            assert(fakeBaseClient.initializeCBS.calledTwice);
-            assert(fakeBaseClient.putToken.calledTwice);
+            assert.strictEqual(err.amqpError, testError);
+            testCallback();
+          });
+        });
+
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_062: [The `getTwin` method shall call the `getTwin` method on the `AmqpTwinClient` instance created by the constructor.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_064: [The `getTwin` method shall call its callback with a `null` error parameter and the result of the `AmqpTwinClient.getTwin` method if it succeeds.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_063: [The `getTwin` method shall call its callback with and error if the call to `AmqpTwinClient.getTwin` fails.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_068: [The `updateTwinReportedProperties` method shall call the `updateTwinReportedProperties` method on the `AmqpTwinClient` instance created by the constructor.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_069: [The `updateTwinReportedProperties` method shall call its callback with and error if the call to `AmqpTwinClient.updateTwinReportedProperties` fails.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_070: [The `updateTwinReportedProperties` method shall call its callback with a `null` error parameter and the result of the `AmqpTwinClient.updateTwinReportedProperties` method if it succeeds.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_074: [The `enableTwinDesiredPropertiesUpdates` method shall call the `enableTwinDesiredPropertiesUpdates` method on the `AmqpTwinClient` instance created by the constructor.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_075: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with and error if the call to `AmqpTwinClient.enableTwinDesiredPropertiesUpdates` fails.]*/
+        /*Tests_SRS_NODE_DEVICE_AMQP_16_076: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with no arguments if the call to `AmqpTwinClient.enableTwinDesiredPropertiesUpdates` succeeds.]*/
+        it('calls its callback with an error if the twin client fails to send the request', function (testCallback) {
+          var testError = new Error('failed to send');
+          sender.send = sinon.stub().callsArgWith(1, testError);
+
+          methodUnderTest(function (err) {
+            assert(fakeBaseClient.connect.calledOnce);
+            assert(fakeBaseClient.initializeCBS.calledOnce);
+            assert(fakeBaseClient.putToken.calledOnce);
             assert(fakeBaseClient.attachReceiverLink.calledOnce);
             assert(fakeBaseClient.attachSenderLink.calledOnce);
+            assert.strictEqual(err.amqpError, testError);
             testCallback();
           });
-
-          disconnectCallback(null, new results.Connected());
         });
-      });
-    });
 
-    describe('#getTwinReceiver', function () {
-      /*Tests_SRS_NODE_DEVICE_AMQP_06_033: [ The `getTwinReceiver` method shall throw an `ReferenceError` if done is falsy.]*/
-      it('throws if done is falsy', function() {
-        assert.throws(function() {
-          transport.getTwinReceiver();
-        }, ReferenceError);
-      });
+        it('tries to reconnect to send the message if the transport is disconnecting', function () {
+          var disconnectCallback;
 
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_026: [The `getTwinReceiver` method shall call the `done` callback with a `null` error argument and the `AmqpTwinClient` instance currently in use.]*/
-      it('calls done when complete', function(done) {
-        transport.getTwinReceiver(done);
-      });
-
-      it('only creates one twin receiver object', function(done) {
-        transport.getTwinReceiver(function(err, receiver1) {
-          assert.isNull(err);
-          assert.instanceOf(receiver1, AmqpTwinClient);
-          transport.getTwinReceiver(function(err, receiver2) {
-            assert.isNull(err);
-            assert.strictEqual(receiver1, receiver2);
-            done();
+          fakeBaseClient.disconnect = sinon.stub().callsFake(function (done) {
+            disconnectCallback = done;
           });
-        });
-      });
 
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_027: [The `getTwinReceiver` method shall connect and authenticate the AMQP connection if necessary.]*/
-      it('connects and authenticates the transport if disconnected', function (testCallback) {
-        transport.getTwinReceiver(function () {
+          methodUnderTest(function () {});
           assert(fakeBaseClient.connect.calledOnce);
           assert(fakeBaseClient.initializeCBS.calledOnce);
           assert(fakeBaseClient.putToken.calledOnce);
-          testCallback();
-        });
-      });
-
-      it('defers until connected and authenticated if called while connecting', function (testCallback) {
-        var connectCallback;
-        fakeBaseClient.connect = sinon.stub().callsFake(function (uri, sslOptions, callback) {
-          connectCallback = callback;
-        });
-
-        transport.connect(function () {});
-        // blocked in the 'connecting' state
-        transport.getTwinReceiver(function () {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert(fakeBaseClient.initializeCBS.calledOnce);
-          assert(fakeBaseClient.putToken.calledOnce);
-          testCallback();
-        });
-
-        assert(fakeBaseClient.connect.calledOnce);
-        assert(fakeBaseClient.initializeCBS.notCalled);
-        assert(fakeBaseClient.putToken.notCalled);
-        connectCallback();
-      });
-
-      it('defers until authenticated if called while authenticating', function (testCallback) {
-        var authCallback;
-        fakeBaseClient.initializeCBS = sinon.stub().callsFake(function (callback) {
-          authCallback = callback;
-        });
-
-        transport.connect(function () {});
-        // blocked in the 'authenticating' state
-        transport.getTwinReceiver(function () {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert(fakeBaseClient.initializeCBS.calledOnce);
-          assert(fakeBaseClient.putToken.calledOnce);
-          testCallback();
-        });
-
-        assert(fakeBaseClient.connect.calledOnce);
-        assert(fakeBaseClient.initializeCBS.calledOnce);
-        assert(fakeBaseClient.putToken.notCalled);
-        authCallback();
-      });
-
-      it('tries to reconnect if called while disconnecting', function (testCallback) {
-        var disconnectCallback;
-        fakeBaseClient.disconnect = sinon.stub().callsFake(function (callback) {
-          disconnectCallback = callback;
-        });
-
-        transport.connect(function () {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert(fakeBaseClient.initializeCBS.calledOnce);
-          assert(fakeBaseClient.putToken.calledOnce);
+          assert(sender.send.calledOnce);
 
           transport.disconnect(function () {});
-          assert(fakeBaseClient.disconnect.calledOnce);
 
-          transport.getTwinReceiver(function () {
-            assert(fakeBaseClient.connect.calledTwice);
-            assert(fakeBaseClient.initializeCBS.calledTwice);
-            assert(fakeBaseClient.putToken.calledTwice);
-            testCallback();
-          });
+          methodUnderTest(function () {});
+          assert(fakeBaseClient.connect.calledOnce);
+          assert(fakeBaseClient.initializeCBS.calledOnce);
+          assert(fakeBaseClient.putToken.calledOnce);
 
-          disconnectCallback();
+          disconnectCallback(null, new results.Disconnected());
+
+          assert(fakeBaseClient.connect.calledTwice);
+          assert(fakeBaseClient.initializeCBS.calledTwice);
+          assert(fakeBaseClient.putToken.calledTwice);
+          assert(fakeBaseClient.attachReceiverLink.calledTwice);
+          assert(fakeBaseClient.attachSenderLink.calledTwice);
         });
       });
+    }
 
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_028: [The `getTwinReceiver` method shall call the `done` callback with the corresponding error if the transport fails connect or authenticate the AMQP connection.]*/
-      it('calls the callback with an error if the transport fails to connect', function (testCallback) {
-        var fakeError = new Error('test');
-        fakeBaseClient.connect = sinon.stub().callsArgWith(2, fakeError);
-        transport.getTwinReceiver(function (err, recv) {
-          assert.strictEqual(err.amqpError, fakeError);
-          assert.isUndefined(recv);
+    testStateMachine('getTwin', function (callback) {
+      transport.getTwin(callback);
+    });
+
+    testStateMachine('updateTwinReportedProperties', function (callback) {
+      transport.updateTwinReportedProperties({ fake: 'patch' }, callback);
+    });
+
+    testStateMachine('enableTwinDesiredPropertiesUpdates', function (callback) {
+      transport.enableTwinDesiredPropertiesUpdates(callback);
+    });
+
+    describe('#disableTwinDesiredPropertiesUpdates', function () {
+      it('calls its callback immediately if the amqp client is disconnected', function (testCallback) {
+        transport.disableTwinDesiredPropertiesUpdates(function () {
+          assert.isTrue(fakeBaseClient.connect.notCalled);
+          assert.isTrue(fakeBaseClient.initializeCBS.notCalled);
+          assert.isTrue(fakeBaseClient.putToken.notCalled);
+          assert.isTrue(fakeBaseClient.attachReceiverLink.notCalled);
+          assert.isTrue(fakeBaseClient.attachSenderLink.notCalled);
           testCallback();
         });
       });
 
-      it('calls the callback with an error if the transport fails to authenticate', function (testCallback) {
-        var fakeError = new Error('test');
-        fakeBaseClient.putToken = sinon.stub().callsArgWith(2, fakeError);
-        transport.getTwinReceiver(function (err, recv) {
-          assert.strictEqual(err.amqpError, fakeError);
-          assert.isUndefined(recv);
+      /*Tests_SRS_NODE_DEVICE_AMQP_16_077: [The `disableTwinDesiredPropertiesUpdates` method shall call the `disableTwinDesiredPropertiesUpdates` method on the `AmqpTwinClient` instance created by the constructor.]*/
+      /*Tests_SRS_NODE_DEVICE_AMQP_16_078: [The `disableTwinDesiredPropertiesUpdates` method shall call its callback with and error if the call to `AmqpTwinClient.disableTwinDesiredPropertiesUpdates` fails.]*/
+      /*Tests_SRS_NODE_DEVICE_AMQP_16_079: [The `disableTwinDesiredPropertiesUpdates` method shall call its callback no arguments if the call to `AmqpTwinClient.disableTwinDesiredPropertiesUpdates` succeeds.]*/
+      it('calls disableTwinDesiredPropertiesUpdates on the twin client', function (testCallback) {
+        transport._twinClient.disableTwinDesiredPropertiesUpdates = sinon.stub().callsArg(0);
+        transport.enableTwinDesiredPropertiesUpdates(function () {});
+        transport.disableTwinDesiredPropertiesUpdates(function () {
+          assert.isTrue(transport._twinClient.disableTwinDesiredPropertiesUpdates.calledOnce);
           testCallback();
         });
       });
     });
 
-    describe('enableTwin', function () {
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_045: [The `enableTwin` method shall connect and authenticate the transport if it is disconnected.]*/
-      it('connects the transport if it is disconnected', function (testCallback) {
-        transport.enableTwin(function () {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert(fakeBaseClient.initializeCBS.calledOnce);
-          assert(fakeBaseClient.putToken.calledOnce);
-          assert(fakeBaseClient.attachSenderLink.calledWith(transport._twinClient._endpoint));
-          assert(fakeBaseClient.attachReceiverLink.calledWith(transport._twinClient._endpoint));
+    describe('on(\'twinDesiredPropertiesUpdate\')', function () {
+      it('emits a twinDesiredPropertiesUpdate if it receives a twinDesiredPropertiesUpdate from the twin client', function (testCallback) {
+        var fakePatch = { fake : 'patch' };
+        transport.on('twinDesiredPropertiesUpdate', function (patch) {
+          assert.strictEqual(patch, fakePatch);
           testCallback();
         });
-      });
 
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_047: [The `enableTwin` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach twin links.]*/
-      it('calls the callback with an error if the transport fails to connect', function (testCallback) {
-        fakeBaseClient.connect = sinon.stub().callsArgWith(2, new Error('fake error'));
-        transport.enableTwin(function (err) {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert.instanceOf(err, Error);
-          testCallback();
-        });
+        transport._twinClient.emit('twinDesiredPropertiesUpdate', fakePatch);
       });
+    });
 
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_047: [The `enableTwin` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach twin links.]*/
-      it('calls the callback with an error if the transport fails to initialize the CBS links', function (testCallback) {
-        fakeBaseClient.initializeCBS = sinon.stub().callsArgWith(0, new Error('fake error'));
-        transport.enableTwin(function (err) {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert(fakeBaseClient.initializeCBS.calledOnce);
-          assert.instanceOf(err, Error);
-          testCallback();
-        });
-      });
-
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_047: [The `enableTwin` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach twin links.]*/
-      it('calls the callback with an error if the transport fails to make a new putToken request on the CBS links', function (testCallback) {
-        fakeBaseClient.putToken = sinon.stub().callsArgWith(2, new Error('fake error'));
-        transport.enableTwin(function (err) {
-          assert(fakeBaseClient.connect.calledOnce);
-          assert(fakeBaseClient.initializeCBS.calledOnce);
-          assert(fakeBaseClient.putToken.calledOnce);
-          assert.instanceOf(err, Error);
-          testCallback();
-        });
-      });
-
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_046: [The `enableTwin` method shall attach the twin links and call its `callback` once these are successfully attached.]*/
-      it('attaches the twin links', function (testCallback) {
-        transport.connect(function () {
-          assert(fakeBaseClient.attachReceiverLink.notCalled);
-          transport.enableTwin(function () {
-            assert(fakeBaseClient.attachSenderLink.calledWith(transport._twinClient._endpoint));
-            assert(fakeBaseClient.attachReceiverLink.calledWith(transport._twinClient._endpoint));
-            testCallback();
-          });
-        });
-      });
-
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_048: [Any `error` event received on any of the links used for twin shall trigger the emission of an `error` event by the transport, with an argument that is a `TwinDetachedError` object with the `innerError` property set to that error.]*/
-      it('calls its callback with an Error if attaching the twin receiver link fails', function (testCallback) {
-        transport._twinClient.attach = sinon.stub().callsArgWith(0, new Error('fake failed to attach'));
-        transport.connect(function () {
-          transport.enableTwin(function (err) {
-            assert(transport._twinClient.attach.calledOnce);
-            assert.instanceOf(err, Error);
-            testCallback();
-          });
-        });
-      });
-
-      it('emits a TwinDetachedError with an innerError property if the link fails after being established correctly', function (testCallback) {
-        var fakeError = new Error('fake twin receiver link error');
+    describe('on(\'error\')', function () {
+      it('emits a TwinDetachedError if it receives an error from the twin client', function (testCallback) {
+        var fakeError = new Error('fake');
         transport.on('error', function (err) {
           assert.instanceOf(err, errors.TwinDetachedError);
           assert.strictEqual(err.innerError, fakeError);
           testCallback();
         });
 
-        transport.connect(function () {
-          transport.enableTwin(function () {
-            transport._twinClient.emit('error', fakeError);
-          });
-        });
-      });
-    });
-
-    describe('disableTwin', function (testCallback) {
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_051: [The `disableTwin` method shall call its `callback` immediately if the transport is already disconnected.]*/
-      it('calls the callback immediately if the transport is disconnected', function (testCallback) {
-        transport.disableTwin(function (err) {
-          assert.isNotOk(err);
-          assert(receiver.detach.notCalled);
-          testCallback();
-        });
-      });
-
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_049: [The `disableTwin` method shall call `detach` on the twin links and call its callback when these are successfully detached.]*/
-      it('detaches the twin links', function (testCallback) {
-        transport._twinClient.detach = sinon.stub().callsArg(0);
-        transport.connect(function () {
-          assert(fakeBaseClient.attachReceiverLink.notCalled);
-          transport.enableTwin(function () {
-            assert(fakeBaseClient.attachSenderLink.calledWith(transport._twinClient._endpoint));
-            assert(fakeBaseClient.attachReceiverLink.calledWith(transport._twinClient._endpoint));
-            transport.disableTwin(function () {
-              assert(transport._twinClient.detach.calledOnce);
-              testCallback();
-            });
-          });
-        });
-      });
-
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_050: [The `disableTwin` method shall call its `callback` with an `Error` if it fails to detach the twin links.]*/
-      it('calls its callback with an Error if an error happens while detaching the twin links', function (testCallback) {
-        transport._twinClient.detach = sinon.stub().callsArgWith(0, new Error('fake detach error'));
-        transport.connect(function () {
-          assert(fakeBaseClient.attachReceiverLink.notCalled);
-          transport.enableTwin(function () {
-            assert(fakeBaseClient.attachSenderLink.calledWith(transport._twinClient._endpoint));
-            assert(fakeBaseClient.attachReceiverLink.calledWith(transport._twinClient._endpoint));
-            transport.disableTwin(function (err) {
-              assert(transport._twinClient.detach.calledOnce);
-              assert.instanceOf(err, Error);
-              testCallback();
-            });
-          });
-        });
+        transport._twinClient.emit('error', fakeError);
       });
     });
   });

--- a/device/transport/amqp/test/_amqp_twin_client_test.js
+++ b/device/transport/amqp/test/_amqp_twin_client_test.js
@@ -8,14 +8,7 @@ var EventEmitter = require('events').EventEmitter;
 var sinon = require('sinon');
 
 var AmqpTwinClient = require('../lib/amqp_twin_client.js').AmqpTwinClient;
-var AmqpProvider = require('./_fake_amqp.js').FakeAmqp;
 var Amqp = require('../lib/amqp').Amqp;
-var AmqpProviderAttachSenderFails = require('./_fake_amqp.js').FakeAmqpAttachSenderFails;
-var AmqpProviderAttachReceiverFails = require('./_fake_amqp.js').FakeAmqpAttachReceiverFails;
-var AmqpProviderDetachSenderFails = require('./_fake_amqp.js').FakeAmqpDetachSenderFails;
-var AmqpProviderDetachReceiverFails = require('./_fake_amqp.js').FakeAmqpDetachReceiverFails;
-var AmqpProviderAttachReceiverDelay = require('./_fake_amqp.js').FakeAmqpAttachReceiverDelayCallback
-var AmqpProviderDetachReceiverDelay = require('./_fake_amqp.js').FakeAmqpDetachReceiverDelayCallback
 var Message = require('azure-iot-common').Message;
 var errors = require('azure-iot-common').errors;
 var endpoint = require('azure-iot-common').endpoint;
@@ -26,12 +19,29 @@ describe('AmqpTwinClient', function () {
     deviceId: 'deviceId'
   };
 
-  var fakeAuthenticationProvider;
+  var fakeAuthenticationProvider, fakeAmqpClient, fakeSenderLink, fakeReceiverLink, twinClient;
 
   beforeEach(function () {
     fakeAuthenticationProvider = {
       getDeviceCredentials: sinon.stub().callsArgWith(0, null, fakeConfig)
     };
+
+    fakeSenderLink = new EventEmitter();
+      fakeSenderLink.send = sinon.stub().callsArg(1)
+
+      fakeReceiverLink = new EventEmitter();
+
+      fakeAmqpClient = {
+        connect: sinon.stub().callsArg(2),
+        initializeCbs: sinon.stub().callsArg(0),
+        putToken: sinon.stub().callsArg(2),
+        attachSenderLink: sinon.stub().callsArgWith(2, null, fakeSenderLink),
+        attachReceiverLink: sinon.stub().callsArgWith(2, null, fakeReceiverLink),
+        detachSenderLink: sinon.stub().callsArg(1),
+        detachReceiverLink: sinon.stub().callsArg(1)
+      };
+
+      twinClient = new AmqpTwinClient(fakeAuthenticationProvider, fakeAmqpClient);
   });
 
   describe('#constructor', function () {
@@ -42,37 +52,47 @@ describe('AmqpTwinClient', function () {
     });
   });
 
-  describe('#response', function () {
-    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_006: [When a listener is added for the `response` event, and the `post` event is NOT already subscribed, upstream and downstream links are established via calls to `attachReceiverLink` and `attachSenderLink`.] */
-    it('calls attachSender and attachReceiver if #post not invoked first', function() {
-      var amqpClient = new AmqpProvider();
-      var attachSender = sinon.spy(amqpClient, 'attachSenderLink');
-      var attachReceiver = sinon.spy(amqpClient, 'attachReceiverLink');
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('response', function () {});
-      assert(attachSender.calledOnce);
-      assert(attachReceiver.calledOnce);
+  function testStateMachine(methodUnderTest) {
+    it('calls getDeviceCredentials on the authentication provider', function () {
+      methodUnderTest();
+      assert.isTrue(fakeAuthenticationProvider.getDeviceCredentials.calledOnce);
     });
 
-    it('ONLY calls attachSender and attachReceiver once if #post is subscribed first', function() {
-      var amqpClient = new AmqpProvider();
-      var attachSender = sinon.spy(amqpClient, 'attachSenderLink');
-      var attachReceiver = sinon.spy(amqpClient, 'attachReceiverLink');
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('post', function() {});
-      newTwinReceiver.on('response', function () {});
-      assert(attachSender.calledOnce);
-      assert(attachReceiver.calledOnce);
+    it('calls its callback with an error if getDeviceCredentials fails', function (testCallback) {
+      var fakeError = new Error('fake');
+      fakeAuthenticationProvider.getDeviceCredentials = sinon.stub().callsArgWith(0, fakeError);
+      methodUnderTest(function (err) {
+        assert.isTrue(fakeAuthenticationProvider.getDeviceCredentials.calledOnce);
+        assert.strictEqual(err, fakeError);
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_007: [The `getTwin` method shall attach the sender link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_009: [THe `getTwin` method shall attach the receiver link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_015: [The `updateTwinReportedProperties` method shall attach the sender link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_017: [THe `updateTwinReportedProperties` method shall attach the receiver link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_023: [The `enableTwinDesiredPropertiesUpdates` method shall attach the sender link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_025: [THe `enableTwinDesiredPropertiesUpdates` method shall attach the receiver link if it's not already attached.]*/
+    it('calls attachSender and attachReceiver if the links are not attached', function() {
+      methodUnderTest();
+      assert.isTrue(fakeAmqpClient.attachSenderLink.calledOnce);
+      assert.isTrue(fakeAmqpClient.attachReceiverLink.calledOnce);
+    });
+
+    it('calls attachSender and attachReceiver only once', function() {
+      methodUnderTest();
+      methodUnderTest();
+      assert.isTrue(fakeAmqpClient.attachSenderLink.calledOnce);
+      assert.isTrue(fakeAmqpClient.attachReceiverLink.calledOnce);
     });
 
     /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_007: [The endpoint argument for attacheReceiverLink shall be `/devices/<deviceId>/twin`.] */
     /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_009: [The endpoint argument for attacheSenderLink shall be `/devices/<deviceId>/twin`.] */
-    it('endpoint argument for attache/Receiver/Sender/Link shall be `/devices/<deviceId>/twin`.', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('response', function () {});
-      assert.equal(amqpClient.attachSenderEndpoint, '/devices/' + fakeConfig.deviceId + '/twin', 'attach sender called with correct endpoint');
-      assert.equal(amqpClient.attachReceiverEndpoint, '/devices/' + fakeConfig.deviceId + '/twin', 'attach receiver called with correct endpoint');
+    it('attaches sender and receiver links to the `/devices/<deviceId>/twin` endpoint.', function() {
+      methodUnderTest();
+      assert.isTrue(fakeAmqpClient.attachSenderLink.calledWith('/devices/' + fakeConfig.deviceId + '/twin'));
+      assert.isTrue(fakeAmqpClient.attachReceiverLink.calledWith('/devices/' + fakeConfig.deviceId + '/twin'));
     });
 
     /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_010: [** The link options argument for attachSenderLink shall be:
@@ -93,687 +113,448 @@ describe('AmqpTwinClient', function () {
                 sndSettleMode: 1,
                 rcvSettleMode: 0
               } ] */
-    it('link options argument for attache/Receiver/Sender/Link shall be ...', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('response', function () {});
-      assert.equal(amqpClient.attachSenderLinkOptions.attach.sndSettleMode, 1, ' sender send settle mode not set appropriately' );
-      assert.equal(amqpClient.attachSenderLinkOptions.attach.rcvSettleMode, 0, ' sender rcv settle mode not set appropriately' );
-      assert.equal(amqpClient.attachReceiverLinkOptions.attach.sndSettleMode, 1, ' receiver send settle mode not set appropriately' );
-      assert.equal(amqpClient.attachReceiverLinkOptions.attach.rcvSettleMode, 0, ' receiver rcv settle mode not set appropriately' );
-      assert.equal(amqpClient.attachSenderLinkOptions.attach.properties['com.microsoft:api-version'], endpoint.apiVersion, ' sender api version not set appropriately');
-      assert.equal(amqpClient.attachReceiverLinkOptions.attach.properties['com.microsoft:api-version'], endpoint.apiVersion, ' receiver api version not set appropriately');
-      assert.equal(amqpClient.attachReceiverLinkOptions.attach.properties['com.microsoft:channel-correlation-id'], amqpClient.attachSenderLinkOptions.attach.properties['com.microsoft:channel-correlation-id'], ' send and receiver correlation not equal');
-      assert(amqpClient.attachSenderLinkOptions.attach.properties['com.microsoft:channel-correlation-id'].length, 41); // 32 hex digits + 4 dashes + twin:
-      assert(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(amqpClient.attachSenderLinkOptions.attach.properties['com.microsoft:channel-correlation-id'].substr(5, 36)), 'correlationId does not contains a uuid');
+    it('configures link options for the sender and receiver links', function() {
+      methodUnderTest();
+      assert.equal(fakeAmqpClient.attachSenderLink.firstCall.args[1].attach.sndSettleMode, 1, ' sender send settle mode not set appropriately' );
+      assert.equal(fakeAmqpClient.attachSenderLink.firstCall.args[1].attach.rcvSettleMode, 0, ' sender rcv settle mode not set appropriately' );
+      assert.equal(fakeAmqpClient.attachReceiverLink.firstCall.args[1].attach.sndSettleMode, 1, ' receiver send settle mode not set appropriately' );
+      assert.equal(fakeAmqpClient.attachReceiverLink.firstCall.args[1].attach.rcvSettleMode, 0, ' receiver rcv settle mode not set appropriately' );
+      assert.equal(fakeAmqpClient.attachSenderLink.firstCall.args[1].attach.properties['com.microsoft:api-version'], endpoint.apiVersion, ' sender api version not set appropriately');
+      assert.equal(fakeAmqpClient.attachReceiverLink.firstCall.args[1].attach.properties['com.microsoft:api-version'], endpoint.apiVersion, ' receiver api version not set appropriately');
+      assert.equal(fakeAmqpClient.attachReceiverLink.firstCall.args[1].attach.properties['com.microsoft:channel-correlation-id'], fakeAmqpClient.attachSenderLink.firstCall.args[1].attach.properties['com.microsoft:channel-correlation-id'], ' send and receiver correlation not equal');
+      assert(fakeAmqpClient.attachReceiverLink.firstCall.args[1].attach.properties['com.microsoft:channel-correlation-id'].length, 41); // 32 hex digits + 4 dashes + twin:
+      assert(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(fakeAmqpClient.attachSenderLink.firstCall.args[1].attach.properties['com.microsoft:channel-correlation-id'].substr(5, 36)), 'correlationId does not contains a uuid');
     });
 
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_011: [** Upon successfully establishing the upstream and downstream links the `subscribed` event shall be emitted from the twin receiver, with an argument object of {eventName: "response", transportObject: <object>}.] */
-    it('subscribe event emitted on successful listen for response', function() {
-      var subCalls = 0;
-      var subResponseCalls = 0;
-      var subPostCalls = 0;
-      var subscribeHandler = function(subObject) {
-        subCalls++;
-        if (subObject.eventName === 'response') {
-          subResponseCalls++;
-        }
-        if (subObject.eventName === 'post') {
-          subPostCalls++;
-        }
-      };
-      var subSpy = sinon.spy();
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('subscribed', subscribeHandler);
-      newTwinReceiver.on('response', function () {});
-      assert.equal(subCalls, 1, 'subscribe handler invoked improper number of times');
-      assert.equal(subResponseCalls, 1, 'response event emitted incorrect number of times')
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_014: [When there are no more listeners for the `response` AND the `post` event, the upstream and downstream amqp links shall be closed via calls to `detachReceiverLink` and `detachSenderLink`.] */
-    it('No more listeners will invoke detach of sender and receiver links.', function() {
-      var amqpClient = new AmqpProvider();
-      var responseFunction = function () {};
-      var attachSender = sinon.spy(amqpClient, 'attachSenderLink');
-      var attachReceiver = sinon.spy(amqpClient, 'attachReceiverLink');
-      var detachSender = sinon.spy(amqpClient, 'detachSenderLink');
-      var detachReceiver = sinon.spy(amqpClient, 'detachReceiverLink');
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('response', responseFunction);
-      assert(detachSender.notCalled);
-      assert(detachReceiver.notCalled);
-      newTwinReceiver.removeListener('response', responseFunction);
-      assert(detachSender.calledOnce);
-      assert(detachReceiver.calledOnce);
-    });
-
-    it('Had two listeners then no more listeners will invoke detach of sender and receiver links.', function() {
-      var amqpClient = new AmqpProvider();
-      var responseFunction = function () {};
-      var attachSender = sinon.spy(amqpClient, 'attachSenderLink');
-      var attachReceiver = sinon.spy(amqpClient, 'attachReceiverLink');
-      var detachSender = sinon.spy(amqpClient, 'detachSenderLink');
-      var detachReceiver = sinon.spy(amqpClient, 'detachReceiverLink');
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('response', responseFunction);
-      newTwinReceiver.on('post', responseFunction);
-      assert(detachSender.notCalled);
-      assert(detachReceiver.notCalled);
-      newTwinReceiver.removeListener('response', responseFunction);
-      assert(detachSender.notCalled);
-      assert(detachReceiver.notCalled);
-      newTwinReceiver.removeListener('post', responseFunction);
-      assert(detachSender.calledOnce);
-      assert(detachReceiver.calledOnce);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_015: [If there is a listener for the `response` event, a `response` event shall be emitted for each response received for requests initiated by SendTwinRequest.] */
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_026: [The `status` value is acquired from the amqp message status message annotation.] */
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_016: [When a `response` event is emitted, the parameter shall be an object which contains `status`, `requestId` and `body` members.] */
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_017: [The `requestId` value is acquired from the amqp message correlationId property in the response amqp message.] */
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_018: [The `body` parameter of the `response` event shall be the data of the received amqp message.] */
-    it('Emit a response message for a sendTwinRequest.', function(responseDone) {
-      var amqpClient = new AmqpProvider();
-      var messageData = 'a string for the body';
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('subscribed', function(event) {
-        if (event.eventName === 'response') {
-          process.nextTick(function () {
-            newTwinReceiver.sendTwinRequest('GET', '/abc', { '$rid' : 10 }, messageData, function() {});
-            //
-            // Form a common message for the receiver link to emit.
-            //
-            var newMessage = new Message();
-            newMessage.correlationId = '10';
-            newMessage.data = messageData;
-            newMessage.transportObj = {};
-            newMessage.transportObj.messageAnnotations = {};
-            newMessage.transportObj.messageAnnotations['status'] = 201;
-            amqpClient.fakeReceiverLink.emit('message', newMessage);
-          });
-        }
-      });
-      newTwinReceiver.on('response', function(data) {
-        assert.isDefined(data.status);
-        assert.equal(data.status, 201, 'returned status is not set appropriately');
-        assert.isDefined(data.$rid);
-        assert.equal(data.$rid, '10', '$rid not set appropriately');
-        assert.isDefined(data.body);
-        assert.equal(data.body, messageData, 'the body was not set appropriately');
-        responseDone();
-      });
-    });
-
-    it('sendTwinRequest while still connecting', function(responseDone) {
-      var amqpClient = new AmqpProviderAttachReceiverDelay();
-      var messageData = 'some string for the body.';
-      var dummyResponseHandler = function() {};
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      var sendCalled = sinon.spy(amqpClient.fakeSenderLink, 'send');
-      newTwinReceiver.on('response', dummyResponseHandler);  // This will start the connecting sequence.
-      assert(sendCalled.notCalled);
-      newTwinReceiver.sendTwinRequest('GET', '/abc', { '$rid' : 10 }, messageData, function() {});
-      assert(sendCalled.notCalled);
-      amqpClient.invokeDelayCallback();
-      assert(sendCalled.calledOnce);
-      responseDone();
-    });
-
-    it('handleNewListener while still connecting', function(testDone) {
-      var amqpClient = new AmqpProviderAttachReceiverDelay();
-      var subscribeCallback = {
-        callbackFunction: function () {}
-      };
-      var subSpy = sinon.spy(subscribeCallback, 'callbackFunction');
-      var dummyResponseHandler = function() {};
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('subscribed', subscribeCallback.callbackFunction);
-      newTwinReceiver.on('response', dummyResponseHandler);  // This will start the connecting sequence.
-      assert(subSpy.notCalled);
-      newTwinReceiver.on('response', dummyResponseHandler);  // Still should be in the connecting sequence.
-      assert(subSpy.notCalled);
-      amqpClient.invokeDelayCallback();  // This should cause the connect sequence to finish.
-      assert(subSpy.calledTwice);
-      testDone();
-    });
-
-    it('handleRemoveListener while still connecting', function(testDone) {
-      var amqpClient = new AmqpProviderAttachReceiverDelay();
-      var subscribeCallback = {
-        callbackFunction: function () {}
-      };
-      var subSpy = sinon.spy(subscribeCallback, 'callbackFunction');
-      var dummyResponseHandler = function() {};
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('subscribed', subscribeCallback.callbackFunction);
-      newTwinReceiver.on('response', dummyResponseHandler);  // This will start the connecting sequence.
-      assert(subSpy.notCalled);
-      newTwinReceiver.on('response', dummyResponseHandler);  // Still should be in the connecting sequence.
-      assert(subSpy.notCalled);
-      newTwinReceiver.removeListener('response', dummyResponseHandler);
-      assert(subSpy.notCalled);
-      amqpClient.invokeDelayCallback();  // This should cause the connect sequence to finish.
-      assert(subSpy.calledTwice);
-      testDone();
-    });
-
-    it('handleRemoveListener while still connecting', function(testDone) {
-      var amqpClient = new AmqpProviderAttachReceiverDelay();
-      var subscribeCallback = {
-        callbackFunction: function () {}
-      };
-      var subSpy = sinon.spy(subscribeCallback, 'callbackFunction');
-      var dummyResponseHandler = function() {};
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('subscribed', subscribeCallback.callbackFunction);
-      newTwinReceiver.on('response', dummyResponseHandler);  // This will start the connecting sequence.
-      assert(subSpy.notCalled);
-      newTwinReceiver.on('response', dummyResponseHandler);  // Still should be in the connecting sequence.
-      assert(subSpy.notCalled);
-      newTwinReceiver.removeListener('response', dummyResponseHandler);
-      assert(subSpy.notCalled);
-      amqpClient.invokeDelayCallback();  // This should cause the connect sequence to finish.
-      assert(subSpy.calledTwice);
-      testDone();
-    });
-
-    it('handle while disconnecting', function(testDone) {
-      var amqpClient = new AmqpProviderDetachReceiverDelay();
-      var subscribeCallback = {
-        callbackFunction: function () {}
-      };
-      var subSpy = sinon.spy(subscribeCallback, 'callbackFunction');
-      var dummyResponseHandler = function() {};
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('subscribed', subscribeCallback.callbackFunction);
-      newTwinReceiver.on('response', dummyResponseHandler);  // This will make us fully connected
-      assert(subSpy.calledOnce); // Should have seen the subscribe
-      //
-      // The next call should start the disconnecting.  However, that
-      // won't complete until force the detach callback.
-      //
-      newTwinReceiver.removeListener('response', dummyResponseHandler);
-      newTwinReceiver.on('response', dummyResponseHandler);  // These next 3 should pend because disconnecting.
-      newTwinReceiver.sendTwinRequest('GET', '/abc', { '$rid' : 10 }, 'not important', function(err) {
-        assert(subSpy.calledOnce); // No subscription should have occurred.
-        assert(err.message === 'Link Detached');
-        testDone();
-      });
-      newTwinReceiver.removeListener('response', dummyResponseHandler);
-      amqpClient.invokeDelayCallback();  // This should cause the disconnect sequence to finish.
-    });
-
-    it('error event in connected causes disconnect', function(testDone) {
-      var errorHandler = function(err) {
-        assert(detachSender.calledOnce, 'detach sender should have been called');
-        assert(detachReceiver.calledOnce, 'detach receiver should have been called');
-        assert.equal(err.constructor.name, 'InternalServerError');
-        testDone();
-      };
-      var amqpClient = new AmqpProvider();
-      var detachSender = sinon.spy(amqpClient, 'detachSenderLink');
-      var detachReceiver = sinon.spy(amqpClient, 'detachReceiverLink');
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('response', function () {});
-      newTwinReceiver.on('error', errorHandler);
-      assert(detachSender.notCalled, 'detach sender should not have been called');
-      assert(detachReceiver.notCalled, 'detach receiver should not have been called');
-      var linkError = new Error();
-      linkError.condition = 'amqp:internal-error'
-      amqpClient.fakeSenderLink.emit('error', linkError);
-    });
-
-  });
-
-  describe('#post', function () {
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_012: [When a listener is added for the `post` event, and the `response` event is NOT already subscribed, upstream and downstream links are established via calls to `attachReceiverLink` and `attachSenderLine`.] */
-    it('calls attachSender and attachReceiver if #response not invoked first', function() {
-      var amqpClient = new AmqpProvider();
-      var attachSender = sinon.spy(amqpClient, 'attachSenderLink');
-      var attachReceiver = sinon.spy(amqpClient, 'attachReceiverLink');
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('post', function () {});
-      assert(attachSender.calledOnce);
-      assert(attachReceiver.calledOnce);
-    });
-
-    it('ONLY calls attachSender and attachReceiver once if #response is subscribed first', function() {
-      var amqpClient = new AmqpProvider();
-      var attachSender = sinon.spy(amqpClient, 'attachSenderLink');
-      var attachReceiver = sinon.spy(amqpClient, 'attachReceiverLink');
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('response', function () {});
-      newTwinReceiver.on('post', function() {});
-      assert(attachSender.calledOnce);
-      assert(attachReceiver.calledOnce);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_013: [Upon receiving a successful response message with the correlationId of the `PUT`, the `subscribed` event shall be emitted from the twin receiver, with an argument object of {eventName: "post", transportObject: <object>}.] */
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_019: [Upon successfully establishing the upstream and downstream links, a `PUT` request shall be sent on the upstream link with a correlationId set in the properties of the amqp message.] */
-    it('calls SendTwinRequest following Link Establishment', function(responseDone) {
-      var resource = '/notifications/twin/properties/desired';
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      var sendCalled = sinon.spy(amqpClient.fakeSenderLink, 'send');
-      newTwinReceiver.on('subscribed', function(event) {
-        if (event.eventName === 'post') {
-          responseDone();
-        }
-      });
-      newTwinReceiver.on('post', function () {});
-      assert(sendCalled.calledOnce, 'sendTwinRequest invoked incorrect number of times');
-      assert.equal(amqpClient.lastSendMessage.messageAnnotations['operation'], 'PUT', 'inappropriate operation sent');
-      assert.equal(amqpClient.lastSendMessage.messageAnnotations['resource'], resource, 'inappropriate resource sent');
-      var newMessage = new Message();
-      newMessage.correlationId = amqpClient.lastSendMessage.properties.correlationId;
-      newMessage.data = '';
-      amqpClient.fakeReceiverLink.emit('message', newMessage);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_020: [If there is a listener for the `post` event, a `post` event shall be emitted for each amqp message received on the downstream link that does NOT contain a correlation id, the parameter of the emit will be is the data of the amqp message.] */
-    it('POST listeners invoked for every desired prop update', function(responseDone) {
-      var amqpClient = new AmqpProvider();
-      var messageData = 'a string of data';
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.on('subscribed', function(event) {
-        if (event.eventName === 'post') {
-          var newDesiredMessage = new Message();
-          newDesiredMessage.data = messageData;
-          amqpClient.fakeReceiverLink.emit('message', newDesiredMessage);
-        }
-      });
-      newTwinReceiver.on('post', function (propUpdate) {
-        if (propUpdate === messageData) {
-          responseDone();
-        }
-      });
-      var newMessage = new Message();
-      newMessage.correlationId = amqpClient.lastSendMessage.properties.correlationId;
-      newMessage.data = '';
-      amqpClient.fakeReceiverLink.emit('message', newMessage);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_021: [When there is no more listeners for the `post` event, a `DELETE` request shall be sent on the upstream link with a correlationId set in the properties of the amqp message.] */
-    it('No more POST listeners results in DELETE message to service', function(responseDone) {
-      var resource = '/notifications/twin/properties/desired';
-      var amqpClient = new AmqpProvider();
-      var dummyPostHandler = function() {};
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      var sendCalled = sinon.spy(amqpClient.fakeSenderLink, 'send');
-      newTwinReceiver.on('subscribed', function(event) {
-        if (event.eventName === 'post') {
-          var deleteResponse = new Message();
-          newTwinReceiver.on('response', function() {});
-          newTwinReceiver.removeListener('post', dummyPostHandler);
-          assert(sendCalled.calledTwice, 'sendTwinRequest invoked incorrect number of times');
-          assert.equal(amqpClient.lastSendMessage.messageAnnotations['operation'], 'DELETE', 'inappropriate operation sent');
-          assert.equal(amqpClient.lastSendMessage.messageAnnotations['resource'], resource, 'inappropriate resource sent');
-          deleteResponse.correlationId = amqpClient.lastSendMessage.properties.correlationId;
-          deleteResponse.data = '';
-          amqpClient.fakeReceiverLink.emit('message', deleteResponse);
-          responseDone();
-        }
-      });
-      newTwinReceiver.on('post', dummyPostHandler);
-      var postResponse = new Message();
-      postResponse.correlationId = amqpClient.lastSendMessage.properties.correlationId;
-      postResponse.data = '';
-      amqpClient.fakeReceiverLink.emit('message', postResponse);
-    });
-
-  });
-
-  describe('#errors', function() {
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_022: [If an error occurs on establishing the upstream or downstream link then the `error` event shall be emitted.] */
-    [
-      { direction: 'sender', provider: AmqpProviderAttachSenderFails },
-      { direction: 'receiver', provider: AmqpProviderAttachReceiverFails }
-    ].forEach(function(operation) {
-      it('twin receiver emits an error if attaching ' + operation.direction + ' link fails', function(testDone) {
-        var amqpClient = new operation.provider();
-        var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-        newTwinReceiver.on('error', function(err) {
-          assert.equal(err.constructor.name, 'UnauthorizedError');
-          testDone();
-        });
-        newTwinReceiver.on('response', function () {});
-      });
-    });
-
-    [
-      { direction: 'sender', provider: AmqpProviderDetachSenderFails },
-      { direction: 'receiver', provider: AmqpProviderDetachReceiverFails }
-    ].forEach(function(operation) {
-      it('twin receiver emits an error if detaching ' + operation.direction + ' link fails', function(testDone) {
-        var amqpClient = new operation.provider();
-        var dummyResponseHandler = function() {};
-        var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-        newTwinReceiver.on('error', function(err) {
-          /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_025: [When the `error` event is emitted, the first parameter shall be an error object obtained via the amqp `translateError` module.] */
-          assert.equal(err.constructor.name, 'UnauthorizedError');
-          testDone();
-        });
-        newTwinReceiver.on('response', dummyResponseHandler);
-        newTwinReceiver.removeListener('response', dummyResponseHandler)
-      });
-    });
-  });
-
-  describe('sendTwinRequest', function () {
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_012: [The `sendTwinRequest` method shall not throw `ReferenceError` if the `done` callback is falsy.] */
-    it('does not throw if done is falsy', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      assert.doesNotThrow(function() {
-        newTwinReceiver.sendTwinRequest('PUT', '/res', { 'rid':10 }, 'body', null);
-      });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_013: [** The `sendTwinRequest` method shall throw an `ReferenceError` if the `method` argument is falsy. **] */
-    it('throws if method is falsy', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      assert.throws(function() {
-        newTwinReceiver.sendTwinRequest(null, '/res', { '$rid':10 }, 'body', function() {});
-      }, ReferenceError);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_017: [The `sendTwinRequest` method shall throw an `ArgumentError` if the `method` argument is not a string.] */
-    it('throws if method is not a string', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      assert.throws(function() {
-        newTwinReceiver.sendTwinRequest({}, '/res', { '$rid':10 }, 'body', function() {});
-      }, errors.ArgumentError);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_014: [The `sendTwinRequest` method shall throw an `ReferenceError` if the `resource` argument is falsy.] */
-    it('throws if resource is falsy', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      assert.throws(function() {
-        newTwinReceiver.sendTwinRequest('PUT', null, { '$rid':10 }, 'body', function() {});
-      }, ReferenceError);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_018: [The `sendTwinRequest` method shall throw an `ArgumentError` if the `resource` argument is not a string.] */
-    it('throws if resource is not a string', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      assert.throws(function() {
-        newTwinReceiver.sendTwinRequest('PUT', {}, { '$rid':10 }, 'body', function() {});
-      }, errors.ArgumentError);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_015: [The `sendTwinRequest` method shall throw an `ReferenceError` if the `properties` argument is falsy.] */
-    it('throws if properties is falsy', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      assert.throws(function() {
-        newTwinReceiver.sendTwinRequest('PUT', '/res', null, 'body', function() {});
-      }, ReferenceError);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_019: [The `sendTwinRequest` method shall throw an `ArgumentError` if the `properties` argument is not a an object.] */
-    it('throws if properties is not an object', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      assert.throws(function() {
-        newTwinReceiver.sendTwinRequest('PUT', '/res', 'properties', 'body', function() {});
-      }, errors.ArgumentError);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_028: [The `sendTwinRequest` method shall throw an `ArgumentError` if any members of the `properties` object fails to serialize to a string.] */
-    it('throws if properties fails to deserialize to a string', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      assert.throws(function() {
-        newTwinReceiver.sendTwinRequest('PUT', '/res', { 'func': function() {} }, 'body', function() {});
-      }, errors.ArgumentError);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_016: [The `sendTwinRequest` method shall throw an `ReferenceError` if the `body` argument is falsy.] */
-    it('throws if body is falsy', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      assert.throws(function() {
-        newTwinReceiver.sendTwinRequest('PUT', '/res', { '$rid' : 10 }, null, function() {});
-      }, ReferenceError);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_020: [The `method` argument shall be the value of the amqp message `operation` annotation.] */
-    it('method argument shall be operation annotation', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.sendTwinRequest('GET', 'abc/', { '$rid' : 10 }, 'a string for the body', function() {});
-      assert.equal(amqpClient.lastSendMessage.messageAnnotations.operation, 'GET', 'operation not set appropriately');
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_021: [The `resource` argument shall be the value of the amqp message `resource` annotation.] */
-    it('resource argument shall be resource annotation', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.sendTwinRequest('GET', '/abc', { '$rid' : 10 }, 'a string for the body', function() {});
-      assert.equal(amqpClient.lastSendMessage.messageAnnotations.resource, '/abc', 'resource not set appropriately');
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_031: [If the `resource` argument terminates in a slash, the slash shall be removed from the annotation.] */
-    it('resource argument terminating slash shall be removed', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.sendTwinRequest('GET', '/abc/', { '$rid' : 10 }, 'a string for the body', function() {});
-      assert.equal(amqpClient.lastSendMessage.messageAnnotations.resource, '/abc', 'resource not set appropriately');
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_039: [If the `resource` argument length is zero (after terminating slash removal), the resource annotation shall not be set.] */
-    it('resource length zero has no resource annotation', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.sendTwinRequest('GET', '/', { '$rid' : 10 }, 'a string for the body', function() {});
-      assert(!amqpClient.lastSendMessage.messageAnnotations.hasOwnProperty('resource'), 'message contains a resource annotation inappropriately');
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_022: [All properties, except $rid, shall be set as the part of the properties map of the amqp message.] */
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_023: [The $rid property shall be set as the `correlationId` in the properties map of the amqp message.] */
-    it('properties of the message set appropriately', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.sendTwinRequest('PATCH', '/', { '$rid' : 10, 'rid': 10, 'from': 'the south', 'to': 'the north' }, 'a string for the body', function() {});
-      assert.isFalse(amqpClient.lastSendMessage.properties.hasOwnProperty('$rid'), '$rid property set inappropriately in message');
-      assert(amqpClient.lastSendMessage.properties.hasOwnProperty('rid'), 'rid property not in message');
-      assert.strictEqual(amqpClient.lastSendMessage.properties['rid'], 10, 'rid property set inappropriately');
-      assert(amqpClient.lastSendMessage.properties.hasOwnProperty('from'), 'from property not in message');
-      assert.strictEqual(amqpClient.lastSendMessage.properties['from'], 'the south', 'from property set inappropriately');
-      assert(amqpClient.lastSendMessage.properties.hasOwnProperty('to'), 'to property not in message');
-      assert.strictEqual(amqpClient.lastSendMessage.properties['to'], 'the north', 'to property set inappropriately');
-      assert(amqpClient.lastSendMessage.properties.hasOwnProperty('correlationId'), 'correlation property not in message');
-      assert.strictEqual(amqpClient.lastSendMessage.properties['correlationId'], '10', 'correlation property set inappropriately');
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_024: [The `body` shall be value of the body of the amqp message.] */
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_025: [The amqp message will be sent upstream to the IoT Hub via the amqp10 client `send`.] */
-    it('body argument shall be value of message body', function() {
-      var amqpClient = new AmqpProvider();
-      var messageData = 'a string for the body';
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.sendTwinRequest('PATCH', '/', { '$rid' : 10, 'rid': 10, 'from': 'the south', 'to': 'the north' }, messageData, function() {});
-      assert(amqpClient.lastSendMessage.hasOwnProperty('body'), 'body property not in message');
-      assert.equal(amqpClient.lastSendMessage.body, messageData, 'body set inappropriately');
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_040: [If an error occurs in the `sendTwinRequest` method, the `done` callback shall be called with the error as the first parameter.] */
-    it('error occurs done shall be called with error as first parameter', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      amqpClient.sendShouldSucceed(false);
-      newTwinReceiver.sendTwinRequest('PATCH', '/', { '$rid' : 10, 'rid': 10, 'from': 'the south', 'to': 'the north' }, 'a string for the body', function(err) {
-        assert(err);
-      });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_041: [If an error occurs, the `sendTwinRequest` shall use the AMQP `translateError` module to convert the amqp-specific error to a transport agnostic error before passing it into the `done` callback.] */
-    it('error occurs shall translated to agnostic message', function() {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      amqpClient.sendShouldSucceed(false);
-      newTwinReceiver.sendTwinRequest('PATCH', '/', { '$rid' : 10, 'rid': 10, 'from': 'the south', 'to': 'the north' }, 'a string for the body', function(err) {
-        assert.equal(err.constructor.name, 'UnauthorizedError');
-      });
-    });
-
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_06_042: [If the `sendTwinRequest` method is successful, the first parameter to the `done` callback shall be null and the second parameter shall be a MessageEnqueued object. **] */
-    it('returns MessageEnqueued object on success', function(done) {
-      var amqpClient = new AmqpProvider();
-      var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      newTwinReceiver.sendTwinRequest('PATCH', '/properties/reported/', { '$rid':10, '$version': 200 }, 'body', function(err, res) {
-        if (err) {
-          done(err);
-        } else {
-          assert.equal(res.constructor.name, 'MessageEnqueued');
-          done();
-        }
-      });
-    });
-  });
-
-  describe('#attach', function () {
-    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_007: [The `attach` method shall call the `getDeviceCredentials` method on the `authenticationProvider` object passed as an argument to the constructor to retrieve the device id.]*/
-    it('calls getDeviceCredentials on the authenticationProvider', function (testCallback) {
-      var amqpClient = new AmqpProvider();
-      var twinClient = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      twinClient.attach(function () {
-        assert.isTrue(fakeAuthenticationProvider.getDeviceCredentials.calledOnce);
-        testCallback();
-      });
-    });
-
-    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_008: [The `attach` method shall call its callback with an error if the call to `getDeviceCredentials` fails with an error.]*/
-    it('calls its callback with an error if the call to getDeviceCredentials fails with an error', function (testCallback) {
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_008: [If attaching the sender link fails, the `getTwin` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_016: [If attaching the sender link fails, the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_024: [If attaching the sender link fails, the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
+    it('calls its callback with an error if it fails to attach the sender link', function (testCallback) {
       var fakeError = new Error('fake');
-      var amqpClient = new AmqpProvider();
-      var twinClient = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      fakeAuthenticationProvider.getDeviceCredentials = sinon.stub().callsArgWith(0, fakeError);
-      twinClient.attach(function (err) {
-        assert.isTrue(fakeAuthenticationProvider.getDeviceCredentials.calledOnce);
+      fakeAmqpClient.attachSenderLink = sinon.stub().callsArgWith(2, fakeError);
+      methodUnderTest(function (err) {
+        assert.instanceOf(err, Error);
         assert.strictEqual(err, fakeError);
         testCallback();
       });
     });
 
-    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_003: [The `attach` method shall call its `callback` immediately if the links are already attached.]*/
-    it('calls the callback immediately if already attached', function (testCallback) {
-      var amqpClient = new AmqpProvider();
-      var twinClient = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      sinon.spy(amqpClient, 'attachReceiverLink');
-      sinon.spy(amqpClient, 'attachSenderLink');
-      twinClient.attach(function () {
-        assert(amqpClient.attachReceiverLink.calledOnce);
-        assert(amqpClient.attachSenderLink.calledOnce);
-        twinClient.attach(function () {
-          assert(amqpClient.attachReceiverLink.calledOnce);
-          assert(amqpClient.attachSenderLink.calledOnce);
-          testCallback();
-        });
-      });
-    });
-
-    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_001: [The `attach` method shall attach both sender and receiver links and calls its `callback` with no argument if successful.]*/
-    it('establishes the links and calls the callback once done', function (testCallback) {
-      var amqpClient = new AmqpProvider();
-      var twinClient = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      sinon.spy(amqpClient, 'attachReceiverLink');
-      sinon.spy(amqpClient, 'attachSenderLink');
-      twinClient.attach(function () {
-        assert(amqpClient.attachReceiverLink.calledOnce);
-        assert(amqpClient.attachSenderLink.calledOnce);
-        testCallback();
-      });
-    });
-
-    // AmqpTwinClient emits an error instead of calling the callback with an error - need to refactor that.
-    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_002: [The `attach` method shall call its `callback` with an `Error` if attaching either link fails.]*/
-    it.skip('calls the callback with an error if establishing the sender fails', function (testCallback) {
-      var amqpClient = new AmqpProviderAttachSenderFails();
-      var twinClient = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      sinon.spy(amqpClient, 'attachReceiverLink');
-      sinon.spy(amqpClient, 'attachSenderLink');
-      twinClient.attach(function (err) {
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_010: [If attaching the receiver link fails, the `getTwin` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_018: [If attaching the receiver link fails, the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_026: [If attaching the receiver link fails, the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
+    it('calls its callback with an error if it fails to attach the receiver link', function (testCallback) {
+      var fakeError = new Error('fake');
+      fakeAmqpClient.attachReceiverLink = sinon.stub().callsArgWith(2, fakeError);
+      methodUnderTest(function (err) {
         assert.instanceOf(err, Error);
+        assert.strictEqual(err, fakeError);
         testCallback();
       });
     });
 
-    // AmqpTwinClient emits an error instead of calling the callback with an error - need to refactor that.
-    it.skip('calls the callback with an error if establishing the receiver fails', function (testCallback) {
-      var amqpClient = new AmqpProviderAttachReceiverFails();
-      var twinClient = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      sinon.spy(amqpClient, 'attachReceiverLink');
-      sinon.spy(amqpClient, 'attachSenderLink');
-      twinClient.attach(function (err) {
-        assert.instanceOf(err, Error);
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_012: [If the `SenderLink.send` call fails the `getTwin` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_020: [If the `SenderLink.send` call fails the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_028: [If the `SenderLink.send` call fails the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
+    it('calls its callback with an error if it fails to send the message', function (testCallback) {
+      var fakeError = new Error('fake');
+      fakeSenderLink.send = sinon.stub().callsArgWith(1, fakeError);
+      methodUnderTest(function (err) {
+        assert.strictEqual(err, fakeError);
         testCallback();
+      });
+    });
+  }
+
+  describe('#getTwin', function () {
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_007: [The `getTwin` method shall attach the sender link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_008: [If attaching the sender link fails, the `getTwin` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_009: [THe `getTwin` method shall attach the receiver link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_010: [If attaching the receiver link fails, the `getTwin` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_012: [If the `SenderLink.send` call fails the `getTwin` method shall call its callback with the error that caused the failure.]*/
+    testStateMachine(function (callback) {
+      twinClient.getTwin(callback);
+    });
+
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_011: [** The `getTwin` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+    - `operation` annotation set to `GET`.
+    - `resource` annotation set to `undefined`
+    - `correlationId` property set to a random integer
+    - `body` set to ` `.]*/
+    it('sends a message with the operation annotation set to GET', function () {
+      twinClient.getTwin(function () {});
+      assert.strictEqual(fakeSenderLink.send.firstCall.args[0].messageAnnotations.operation, 'GET');
+    });
+
+    it('sends a message with no resource annotation', function () {
+      twinClient.getTwin(function () {});
+      assert.isUndefined(fakeSenderLink.send.firstCall.args[0].messageAnnotations.resource);
+    });
+
+    it('sends a message with a correlation id that is an integer', function () {
+      twinClient.getTwin(function () {});
+      var correlationId = parseInt(fakeSenderLink.send.firstCall.args[0].properties.correlationId);
+      assert.isNumber(correlationId);
+      assert.isNotNaN(correlationId);
+    });
+
+    it('sends a message with an empty body', function () {
+      twinClient.getTwin(function () {});
+      assert.strictEqual(fakeSenderLink.send.firstCall.args[0].body, ' ');
+    });
+
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_013: [The `getTwin` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler and until a message with the same `correlationId` as the one that was sent is received.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_014: [The `getTwin` method shall parse the body of the received message and call its callback with a `null` error object and the parsed object as a result.]*/
+    it('parses the response from the body of the corresponding response message', function (testCallback) {
+      var fakeTwin = { fake : 'twin' };
+      twinClient.getTwin(function (err, twin) {
+        assert.deepEqual(twin, fakeTwin);
+        testCallback();
+      });
+
+      fakeReceiverLink.emit('message', {
+        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        data: new Buffer(JSON.stringify(fakeTwin))
       });
     });
   });
 
-  describe('detach', function () {
-    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_005: [The `detach` method shall detach the links and call its `callback` with no arguments if the links are successfully detached.]*/
-    it('detaches the links and calls its callback once done', function (testCallback) {
-      var amqpClient = new AmqpProvider();
-      var twinClient = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      sinon.spy(amqpClient, 'attachReceiverLink');
-      sinon.spy(amqpClient, 'attachSenderLink');
-      sinon.spy(amqpClient, 'detachReceiverLink');
-      sinon.spy(amqpClient, 'detachSenderLink');
-      twinClient.attach(function () {
-        twinClient.detach(function () {
-          assert(amqpClient.attachReceiverLink.calledOnce);
-          assert(amqpClient.attachSenderLink.calledOnce);
-          assert(amqpClient.detachReceiverLink.calledOnce);
-          assert(amqpClient.detachSenderLink.calledOnce);
+  describe('#updateTwinReportedProperties', function () {
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_015: [The `updateTwinReportedProperties` method shall attach the sender link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_017: [THe `updateTwinReportedProperties` method shall attach the receiver link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_016: [If attaching the sender link fails, the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_018: [If attaching the receiver link fails, the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_020: [If the `SenderLink.send` call fails the `updateTwinReportedProperties` method shall call its callback with the error that caused the failure.]*/
+    testStateMachine(function (callback) {
+      twinClient.updateTwinReportedProperties({ fake: 'patch' }, callback);
+    });
+
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_019: [The `updateTwinReportedProperties` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+    - `operation` annotation set to `PATCH`.
+    - `resource` annotation set to `/properties/reported`
+    - `correlationId` property set to a random integer
+    - `body` set to the stringified patch object.]*/
+    it('sends a message with the operation annotation set to PATCH', function () {
+      twinClient.updateTwinReportedProperties({ fake: 'patch' }, function () {});
+      assert.strictEqual(fakeSenderLink.send.firstCall.args[0].messageAnnotations.operation, 'PATCH');
+    });
+
+    it('sends a message with the resource annotation set to /properties/reported', function () {
+      twinClient.updateTwinReportedProperties({ fake: 'patch' }, function () {});
+      assert.strictEqual(fakeSenderLink.send.firstCall.args[0].messageAnnotations.resource, '/properties/reported');
+    });
+
+    it('sends a message with a correlation id that is an integer', function () {
+      twinClient.updateTwinReportedProperties({ fake: 'patch' }, function () {});
+      var correlationId = parseInt(fakeSenderLink.send.firstCall.args[0].properties.correlationId);
+      assert.isNumber(correlationId);
+      assert.isNotNaN(correlationId);
+    });
+
+    it('sends a message with the body set to the stringified patch content', function () {
+      var fakePatch = { fake: 'patch' };
+      twinClient.updateTwinReportedProperties(fakePatch, function () {});
+      assert.strictEqual(fakeSenderLink.send.firstCall.args[0].body, JSON.stringify(fakePatch));
+    });
+  });
+
+  describe('#enableTwinDesiredPropertiesUpdates', function () {
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_023: [The `enableTwinDesiredPropertiesUpdates` method shall attach the sender link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_024: [If attaching the sender link fails, the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_025: [THe `enableTwinDesiredPropertiesUpdates` method shall attach the receiver link if it's not already attached.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_026: [If attaching the receiver link fails, the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_028: [If the `SenderLink.send` call fails the `enableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
+    testStateMachine(function (callback) {
+      twinClient.enableTwinDesiredPropertiesUpdates(callback);
+    });
+
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_027: [The `enableTwinDesiredPropertiesUpdates` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+    - `operation` annotation set to `PUT`.
+    - `resource` annotation set to `/notifications/twin/properties/desired`
+    - `correlationId` property set to a random integer
+    - `body` set to `undefined`.]*/
+    it('sends a message with the operation annotation set to PUT', function () {
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {});
+      assert.strictEqual(fakeSenderLink.send.firstCall.args[0].messageAnnotations.operation, 'PUT');
+    });
+
+    it('sends a message with the resource annotation set to /notifications/twin/properties/desired', function () {
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {});
+      assert.strictEqual(fakeSenderLink.send.firstCall.args[0].messageAnnotations.resource, '/notifications/twin/properties/desired');
+    });
+
+    it('sends a message with a correlation id that is an integer', function () {
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {});
+      var correlationId = parseInt(fakeSenderLink.send.firstCall.args[0].properties.correlationId);
+      assert.isNumber(correlationId);
+      assert.isNotNaN(correlationId);
+    });
+
+    it('sends a message with an empty body', function () {
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {});
+      assert.strictEqual(fakeSenderLink.send.firstCall.args[0].body, ' ');
+    });
+  });
+
+
+  describe('#disableTwinDesiredPropertiesUpdates', function () {
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_031: [The `disableTwinDesiredPropertiesUpdates` method shall call its callback immediately and with no arguments if the links are detached.]*/
+    it('does not attach or send a message if already detached', function () {
+      twinClient.disableTwinDesiredPropertiesUpdates(function () {});
+      assert.isTrue(fakeAmqpClient.attachReceiverLink.notCalled);
+      assert.isTrue(fakeAmqpClient.attachSenderLink.notCalled);
+      assert.isTrue(fakeSenderLink.send.notCalled);
+    });
+
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_032: [The `disableTwinDesiredPropertiesUpdates` method shall send an `AmqpMessage` using the `SenderLink.send` method with the following annotations and properties:
+    - `operation` annotation set to `DELETE`.
+    - `resource` annotation set to `/notifications/twin/properties/desired`
+    - `correlationId` property set to a random integer
+    - `body` set to `undefined`.]*/
+    it('sends a message with the operation annotation set to DELETE', function (testCallback) {
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {
+        twinClient.disableTwinDesiredPropertiesUpdates(function () {});
+        assert.strictEqual(fakeSenderLink.send.secondCall.args[0].messageAnnotations.operation, 'DELETE');
+        testCallback();
+      });
+      fakeReceiverLink.emit('message', {
+        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        messageAnnotations: {
+          status: 200
+        },
+        data: undefined
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_033: [If the `SenderLink.send` call fails the `disableTwinDesiredPropertiesUpdates` method shall call its callback with the error that caused the failure.]*/
+    it('calls its callback with an error if it fails to send the message', function (testCallback) {
+      var fakeError = new Error('fake');
+      fakeSenderLink.send = sinon.stub().callsArgWith(1, fakeError);
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {
+        twinClient.disableTwinDesiredPropertiesUpdates(function (err) {
+          assert.strictEqual(err, fakeError);
           testCallback();
         });
       });
+
+      fakeReceiverLink.emit('message', {
+        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        messageAnnotations: {
+          status: 200
+        },
+        data: undefined
+      });
     });
 
+    it('sends a message with the resource annotation set to /notifications/twin/properties/desired', function (testCallback) {
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {
+        twinClient.disableTwinDesiredPropertiesUpdates(function () {});
+        assert.strictEqual(fakeSenderLink.send.firstCall.args[0].messageAnnotations.resource, '/notifications/twin/properties/desired');
+        testCallback();
+      });
+      fakeReceiverLink.emit('message', {
+        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        messageAnnotations: {
+          status: 200
+        },
+        data: undefined
+      });
+    });
+
+    it('sends a message with a correlation id that is an integer', function (testCallback) {
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {
+        twinClient.disableTwinDesiredPropertiesUpdates(function () {});
+        var correlationId = parseInt(fakeSenderLink.send.secondCall.args[0].properties.correlationId);
+        assert.isNumber(correlationId);
+        assert.isNotNaN(correlationId);
+        testCallback();
+      });
+      fakeReceiverLink.emit('message', {
+        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        messageAnnotations: {
+          status: 200
+        },
+        data: undefined
+      });
+    });
+
+    it('sends a message with an empty body', function (testCallback) {
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {
+        twinClient.disableTwinDesiredPropertiesUpdates(function () {});
+        assert.strictEqual(fakeSenderLink.send.firstCall.args[0].body, ' ');
+        testCallback();
+      });
+      fakeReceiverLink.emit('message', {
+        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        messageAnnotations: {
+          status: 200
+        },
+        data: undefined
+      });
+    });
+  });
+
+  describe('#detach', function () {
     /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_004: [The `detach` method shall call its `callback` immediately if the links are already detached.]*/
-    it('calls its callback immediately if already detached', function (testCallback) {
-      var amqpClient = new AmqpProvider();
-      var twinClient = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      sinon.spy(amqpClient, 'attachReceiverLink');
-      sinon.spy(amqpClient, 'attachSenderLink');
-      sinon.spy(amqpClient, 'detachReceiverLink');
-      sinon.spy(amqpClient, 'detachSenderLink');
+    it('calls its callback immediately if not already connected', function (testCallback) {
       twinClient.detach(function () {
-        assert(amqpClient.attachReceiverLink.notCalled);
-        assert(amqpClient.attachSenderLink.notCalled);
-        assert(amqpClient.detachReceiverLink.notCalled);
-        assert(amqpClient.detachSenderLink.notCalled);
+        assert.isTrue(fakeAmqpClient.attachSenderLink.notCalled);
+        assert.isTrue(fakeAmqpClient.attachReceiverLink.notCalled);
         testCallback();
       });
     });
 
-    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_006: [The `detach` method shall call its `callback` with an `Error` if detaching either of the links fail.]*/
-    it.skip('calls its callback with an error if detaching the sender fails', function (testCallback) {
-      var amqpClient = new AmqpProviderDetachSenderFails();
-      var twinClient = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      twinClient.detach(function (err) {
-        assert.instanceOf(err, Error);
-        testCallback();
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_005: [The `detach` method shall detach the links and call its `callback` with no arguments if the links are successfully detached.]*/
+    it('calls its callback after detaching both links', function (testCallback) {
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {
+        assert.isTrue(fakeAmqpClient.attachSenderLink.calledOnce);
+        assert.isTrue(fakeAmqpClient.attachReceiverLink.calledOnce);
+        twinClient.detach(function () {
+          assert.isTrue(fakeAmqpClient.detachSenderLink.calledOnce);
+          assert.isTrue(fakeAmqpClient.detachReceiverLink.calledOnce);
+          testCallback();
+        });
+      });
+      fakeReceiverLink.emit('message', {
+        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        messageAnnotations: {
+          status: 200
+        },
+        data: undefined
       });
     });
 
     /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_006: [The `detach` method shall call its `callback` with an `Error` if detaching either of the links fail.]*/
-    it.skip('calls its callback with an error if detaching the receiver fails', function (testCallback) {
-      var amqpClient = new AmqpProviderDetachReceiverFails();
-      var twinClient = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-      twinClient.detach(function (err) {
-        assert.instanceOf(err, Error);
-        testCallback();
+    it('calls its callback with an error if detaching the sender link fails', function (testCallback) {
+      var fakeError = new Error('fake');
+      fakeAmqpClient.detachSenderLink = sinon.stub().callsArgWith(1, fakeError);
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {
+        assert.isTrue(fakeAmqpClient.attachSenderLink.calledOnce);
+        assert.isTrue(fakeAmqpClient.attachReceiverLink.calledOnce);
+        twinClient.detach(function (err) {
+          assert.isTrue(fakeAmqpClient.detachSenderLink.calledOnce);
+          assert.isTrue(fakeAmqpClient.detachReceiverLink.calledOnce);
+          assert.strictEqual(err, fakeError);
+          testCallback();
+        });
+      });
+      fakeReceiverLink.emit('message', {
+        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        messageAnnotations: {
+          status: 200
+        },
+        data: undefined
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_AMQP_TWIN_16_006: [The `detach` method shall call its `callback` with an `Error` if detaching either of the links fail.]*/
+    it('calls its callback with an error if detaching the receiver link fails', function (testCallback) {
+      var fakeError = new Error('fake');
+      fakeAmqpClient.detachReceiverLink = sinon.stub().callsArgWith(1, fakeError);
+      twinClient.enableTwinDesiredPropertiesUpdates(function () {
+        assert.isTrue(fakeAmqpClient.attachSenderLink.calledOnce);
+        assert.isTrue(fakeAmqpClient.attachReceiverLink.calledOnce);
+        twinClient.detach(function (err) {
+          assert.isTrue(fakeAmqpClient.detachSenderLink.calledOnce);
+          assert.isTrue(fakeAmqpClient.detachReceiverLink.calledOnce);
+          assert.strictEqual(err, fakeError);
+          testCallback();
+        });
+      });
+      fakeReceiverLink.emit('message', {
+        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        messageAnnotations: {
+          status: 200
+        },
+        data: undefined
+      });
+    });
+  });
+
+  describe('#events', function () {
+    describe('twinDesiredPropertiesUpdate', function () {
+      it('emits a twinDesiredPropertiesUpdate event if a desired properties patch is received', function (testCallback) {
+        var desiredPropDelta = {
+          fake: 'patch'
+        };
+        twinClient.on('twinDesiredPropertiesUpdate', function (delta) {
+          assert.deepEqual(delta, desiredPropDelta);
+          testCallback();
+        });
+
+        twinClient.enableTwinDesiredPropertiesUpdates(function () {
+          fakeReceiverLink.emit('message', {
+            data: JSON.stringify(desiredPropDelta)
+          });
+        });
+        fakeReceiverLink.emit('message', {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+          messageAnnotations: {
+            status: 200
+          },
+          data: undefined
+        });
+      });
+
+      it('ignores a message that has no correlationId and no data', function () {
+        twinClient.on('twinDesiredPropertiesUpdate', function (delta) {
+          assert.fail();
+        });
+        twinClient.on('error', function (delta) {
+          assert.fail();
+        });
+
+        twinClient.enableTwinDesiredPropertiesUpdates(function () {
+          fakeReceiverLink.emit('message', {});
+        });
+        fakeReceiverLink.emit('message', {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+          messageAnnotations: {
+            status: 200
+          },
+          data: undefined
+        });
+      })
+    });
+
+    describe('error', function () {
+      it('detaches the links and emits an error if an error is received on the sender link', function (testCallback) {
+        var fakeError = new Error('fake');
+        twinClient.on('error', function (err) {
+          assert.strictEqual(err, fakeError);
+          assert.isTrue(fakeAmqpClient.detachSenderLink.calledOnce);
+          assert.isTrue(fakeAmqpClient.detachReceiverLink.calledOnce);
+          testCallback();
+        })
+        twinClient.enableTwinDesiredPropertiesUpdates(function () {
+          fakeSenderLink.emit('error', fakeError);
+        });
+        fakeReceiverLink.emit('message', {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+          messageAnnotations: {
+            status: 200
+          },
+          data: undefined
+        });
+      });
+
+      it('detaches the links and emits an error if an error is received on the receiver link', function (testCallback) {
+        var fakeError = new Error('fake');
+        twinClient.on('error', function (err) {
+          assert.strictEqual(err, fakeError);
+          assert.isTrue(fakeAmqpClient.detachSenderLink.calledOnce);
+          assert.isTrue(fakeAmqpClient.detachReceiverLink.calledOnce);
+          testCallback();
+        })
+        twinClient.enableTwinDesiredPropertiesUpdates(function () {
+          fakeReceiverLink.emit('error', fakeError);
+        });
+        fakeReceiverLink.emit('message', {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+          messageAnnotations: {
+            status: 200
+          },
+          data: undefined
+        });
       });
     });
   });


### PR DESCRIPTION
This PR contains refactoring for the AMQP implementation of the twin.
The previous one contained the MQTT implementation and the next one will take care of the client.
All will be merged together as one.