### PR TITLE
fix(twin): Device Client implementation of the refactored twin (also: HTTP stubs)

### DIFF
--- a/device/core/devdoc/device_client_requirements.md
+++ b/device/core/devdoc/device_client_requirements.md
@@ -192,11 +192,9 @@ The `sendEventBatch` method sends a list of event messages to the IoT Hub as the
 
 #### getTwin(done)
 
-**SRS_NODE_DEVICE_CLIENT_18_001: [** The `getTwin` method shall call the `azure-iot-device-core!Twin.fromDeviceClient` method to create the device twin object. **]**
+**SRS_NODE_DEVICE_CLIENT_16_094: [** If this is the first call to `getTwin` the method shall instantiate a new `Twin` object  and pass it the transport currently in use. **]**
 
-**SRS_NODE_DEVICE_CLIENT_18_002: [** The `getTwin` method shall pass itself as the first parameter to `fromDeviceClient` and it shall pass the `done` method as the second parameter. **]**
-
-**SRS_NODE_DEVICE_CLIENT_18_003: [** The `getTwin` method shall use the second parameter (if it is not falsy) to call `fromDeviceClient` on. **]**
+**SRS_NODE_DEVICE_CLIENT_16_095: [** The `getTwin` method shall call the `get()` method on the `Twin` object currently in use and pass it its `done` argument for a callback. **]**
 
 #### onDeviceMethod(methodName, callback)
 

--- a/device/core/devdoc/device_client_requirements.md
+++ b/device/core/devdoc/device_client_requirements.md
@@ -248,6 +248,8 @@ interface DeviceMethodEventHandler {
 
 **SRS_NODE_DEVICE_CLIENT_16_086: [** Any operation (such as `sendEvent` or `onDeviceMethod`) happening after a `setRetryPolicy` call should use the policy set during that call. **]**
 
+**SRS_NODE_DEVICE_CLIENT_16_096: [** The `setRetryPolicy` method shall call the `setRetryPolicy` method on the twin if it is set and pass it the `policy` object. **]**
+
 ### Events
 #### message
 
@@ -270,3 +272,15 @@ interface DeviceMethodEventHandler {
 #### disconnect
 
 **SRS_NODE_DEVICE_CLIENT_16_019: [** The `disconnect` event shall be emitted when the client is disconnected from the server. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_097: [** If the transport emits a `disconnect` event the client while subscribed to C2D messages the retry policy shall try to re-enable the C2D functionality using the transport `enableC2D` method. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_102: [** If the retry policy fails to reestablish the C2D functionality a `disconnect` event shall be emitted with a `results.Disconnected` object. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_098: [** If the transport emits a `disconnect` event the client while subscribed to direct methods the retry policy shall try to re-enable the direct methods functionality using the transport `enableMethods` method. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_100: [** If the retry policy fails to reestablish the direct methods functionality a `disconnect` event shall be emitted with a `results.Disconnected` object. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_099: [** If the transport emits a `disconnect` event the client while subscribed to desired properties updates the retry policy shall try to re-enable the twin desired properties updates using the transport `enableTwinDesiredPropertiesUpdates` method. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_101: [** If the retry policy fails to reestablish the twin desired properties updates functionality a `disconnect` event shall be emitted with a `results.Disconnected` object. **]**

--- a/device/core/devdoc/device_twin_requirements.md
+++ b/device/core/devdoc/device_twin_requirements.md
@@ -3,146 +3,71 @@
 ## Overview
 azure-iot-device.Twin provides access to the Device Twin functionaliy of IoTHub.
 
-## Example usage
-```js
-var Protocol = require('azure-iot-device-mqtt').Mqtt;
-var Client = require('azure-iot-device').Client;
+## Public Interface
 
-// Create IoT Hub client
-var client = Client.fromConnectionString('[IoT Hub device connection string]', Protocol);
-
-// Create device Twin
-client.getTwin(client, function(err, thermostat) {
-  if (err) {
-  console.error('could not establish connection to twin');
-} else {
-  console.log('connected to twin');
-
-  var patch = {
-    firmwareVersion: deviceFirmwareVersion,
-    climate : { 
-      humidity: 90, 
-      temperature: 72 
-      }
-  };
-
-  // Report firmare version and tempeature.
-  thermostat.properties.reported.update(patch, function(err) {
-    if (err) {
-      console.error('update failed');
-    } else {
-      console.log('twin state updated successfully');
+```typescript
+class Twin extends EventEmitter {
+  constructor(transport: Client.Transport);
+  get(callback: (err: Error, twin?: Twin) => void): void;
+  properties: {
+    reported: {
+      [key: string]: any,
+      update: ((err?: Error) => void): void;
+    },
+    desired: {
+      [key: string]: any
     }
-  });
-
-  thermostat.on('properties.desired', function(patch) {
-    console.log('patch received:');
-    console.log(patch);
-  });
-
-});
- 
-
+  }
+}
 ```
+
+### constructor(transport: Client.Transport);
+
+**SRS_NODE_DEVICE_TWIN_16_001: [** The `Twin` constructor shall subscribe to the `onDesiredPropertiesUpdate` event off the `transport` object. **]**
+
+### get(callback: (err: Error, twin?: Twin) => void): void;
+
+**SRS_NODE_DEVICE_TWIN_16_002: [** The `get` method shall call the `getTwin` method of the `Transport` object with a callback. **]**
+
+**SRS_NODE_DEVICE_TWIN_16_003: [** If the callback passed to the `getTwin` method is called with an error, the `callback` passed to the call to the `get` method shall be called with that error. **]**
+
+**SRS_NODE_DEVICE_TWIN_16_004: [** If the callback passed to the `getTwin` method is called with no error and a `TwinProperties` object, these properties shall be merged with the current instance properties. **]**
+
+**SRS_NODE_DEVICE_TWIN_16_005: [** Once the properties have been merged the `callback` method passed to the call to `get` shall be called with a first argument that is `null` and a second argument that is the current `Twin` instance (`this`). **]**
+
+**SRS_NODE_DEVICE_TWIN_16_006: [** For each desired property that is part of the `TwinProperties` object received, an event named after the path to this property shall be fired. **]**
+
+### properties.reported.update(state: any, done: (err?: null) => void): void;
+`update` is a method which application developers use to send reported state to the service.
+
+**SRS_NODE_DEVICE_TWIN_16_007: [** The `update` method shall call the `updateReportedProperties` method of the `Transport` object and pass it the patch object and a callback accepting an error as argument. **]**
+
+**SRS_NODE_DEVICE_TWIN_16_008: [** If the callback passed to the transport is called with an error, the `callback` argument of the `update` method shall be called with that error. **]**
+
+**SRS_NODE_DEVICE_TWIN_18_031: [** If the callback passed to the transport is called with no error, the  `properties.reported.update` shall merge the contents of the patch object into `properties.reported` **]**
+
+**SRS_NODE_DEVICE_TWIN_18_032: [** When merging the patch, if any properties are set to `null`, `properties.reported.update` shall delete that property from `properties.reported`. **]**
+
+**SRS_NODE_DEVICE_TWIN_16_009: [** Once the properties have been merged the `callback` argument of the `update` method shall be called with no argument. **]**
+
+### on('properties.desired[.path])
+
+**SRS_NODE_DEVICE_TWIN_16_010: [** When a listener is added for an event name starting with `properties.desired` the `enableTwinDesiredPropertiesUpdates` method of the `Transport` object shall be called with a callback function accepting an optional error argument. **]**
+
+**SRS_NODE_DEVICE_TWIN_16_011: [** If the callback passed to the transport is called with an error, that error shall be emitted by the Twin object. **]**
+
+**SRS_NODE_DEVICE_TWIN_18_045: [** If a property is already set when a handler is added for that property, the `Twin` object shall fire a property changed event for the property. **]**
+
+**SRS_NODE_DEVICE_TWIN_16_012: [** When a `twinDesiredPropertiesUpdates` event is emitted by the transport, the property patch passed as argument to the event handler shall be merged with the current desired properties. **]**
+
+**SRS_NODE_DEVICE_TWIN_16_013: [** Recursively for each desired property that is part of the patch received, an event named using the convention `properties.desired[.path]` shall be fired with an argument containing the value of the property. **]**
+
 
 ## Implementation notes
 
-All service-to-device version identifiers are ignored.  No device-to-service version identifiers shall be sent.  
+All service-to-device version identifiers are ignored.  No device-to-service version identifiers shall be sent.
 
 TODO: All PATCHes arriving before the GET response comes back shall be ignored.
 
 TODO: handle re-connection.  Need to unsub, resub, and get.  We can't currently do this because the transport doesn't have an "onConnectionDropped" event.
-
-## Public Interface
-
-
-### `fromDeviceClient` method (static)
-The `fromDeviceclient` method creates a device twin connection to the given hub and calls the `done` method after the connection is complete.
-
-**SRS_NODE_DEVICE_TWIN_18_002: [** `fromDeviceclient` shall throw `ReferenceError` if the `client` object is falsy **]**
-
-**SRS_NODE_DEVICE_TWIN_18_030: [** `fromDeviceclient` shall throw `ReferenceError` if the `done` argument is falsy **]**
-
-**SRS_NODE_DEVICE_TWIN_18_028: [** if `fromDeviceClient` has previously been called for this client, it shall perform a GET operation and return the same object **]**
-
-**SRS_NODE_DEVICE_TWIN_18_029: [** if `fromDeviceClient` is called with 2 different `client`s, it shall return 2 unique `Twin` objects **]**
-
-**SRS_NODE_DEVICE_TWIN_18_003: [** `fromDeviceClient` shall allocate a new `Twin` object **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_004: [** `fromDeviceClient` shall call `getTwinReceiver` on the protocol object to get a twin receiver. **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_005: [** If the protocol does not contain a `getTwinReceiver` method, `fromDeviceClient` shall throw a `NotImplementedError` error **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_007: [** `fromDeviceClient` shall add handlers for the both the `subscribed` and `error` events on the twinReceiver **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_031: [** `fromDeviceClient` shall subscribe to the response topic **]**
-
-**SRS_NODE_DEVICE_TWIN_18_032: [** `fromDeviceClient` shall subscribe to the desired property patch topic **]**
-
-**SRS_NODE_DEVICE_TWIN_18_009: [** `fromDeviceClient` shall call the `done` callback passing a `TimeoutError` if it has not received all necessary `subscribed` events within `Twin.timeout` milliseconds. **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_010: [** `fromDeviceClient` shall call the `done` callback passing  the first error that is returned from `error` event on the twinReceiver. **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_044: [** `fromDeviceClient` shall do a GET call to retrieve desired properties from the service. **]**
-
-**SRS_NODE_DEVICE_TWIN_18_043: [** If the GET operation fails, `fromDeviceClient` shall call the done method with the error object in the first parameter **]**
-
-**SRS_NODE_DEVICE_TWIN_18_034: [** `fromDeviceClient` shall ignore any PATCH operations that arrive before the GET returns **]**
-
-**SRS_NODE_DEVICE_TWIN_18_012: [** `fromDeviceClient` shall remove the handlers for both the `subscribed` and `error` events before calling the `done` callback. **]**
-
-
-### _sendTwinRequest method (private)
-`_sendTwinRequest` is a helper method which sends an arbitrary message to the hub and waits for a response (or timeout or error)
-
-**SRS_NODE_DEVICE_TWIN_18_014: [** `_sendTwinRequest` shall use an arbitrary starting `rid` and increment it by one for every call to `_sendTwinRequest` **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_015: [** `_sendTwinRequest` shall add a handler for the `response` event on the twinReceiver object.  **]**
-
-**SRS_NODE_DEVICE_TWIN_18_016: [** `_sendTwinRequest` shall use the `sendTwinRequest` method on the transport to send the request **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_017: [** `_sendTwinRequest` shall put the `rid` value into the `properties` object that gets passed to `sendTwinRequest` on the transport **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_018: [** The response handler shall ignore any messages that don't have an `rid` that matches the `rid` of the request **]**  
-
-**SRS_NODE_DEVICE_TWIN_18_019: [** `_sendTwinRequest` shall call `done` with `err`=`null` if the response event returns `status`===200 or 204 **]**  
-
-**SRS_NODE_DEVICE_TWIN_18_020: [** `_sendTwinRequest` shall call `done` with an `err` value translated using `translateError`  **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_021: [** Before calling `done`, `_sendTwinRequest` shall remove the handler for the `response` event **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_022: [** If the response doesn't come within `Twin.timeout` milliseconds, `_sendTwinRequest` shall call `done` with `err`=`TimeoutError` **]**  
-
-
-### properties.reported.update method
-`update` is a method which application developers use to send reported state to the service.
-
-**SRS_NODE_DEVICE_TWIN_18_025: [** `properties.reported.update` shall use _sendTwinRequest to send the patch object to the service. **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_026: [** When calling `_sendTwinRequest`, `properties.reported.update` shall pass `method`='PATCH', `resource`='/properties/reported/', `properties`={}, and `body`=the `body` parameter passed in to `reportState` as a string. **]**   
-
-**SRS_NODE_DEVICE_TWIN_18_027: [** `properties.reported.update` shall call `done` with the results from `_sendTwinRequest` **]** 
-
-**SRS_NODE_DEVICE_TWIN_18_031: [** `properties.reported.update` shall merge the contents of the patch object into `properties.reported` **]**
-
-**SRS_NODE_DEVICE_TWIN_18_032: [** When merging the patch, if any properties are set to `null`, `properties.reported.update` shall delete that property from `properties.reported`. **]**
-
-**SRS_NODE_DEVICE_TWIN_18_033: [** If `_sendTwinRequest` fails, `properties.reported.update` shall not merge the contents of the patch object into `properties.reported` **]**
-
-
-### events for desired property changes
-
-**SRS_NODE_DEVICE_TWIN_18_035: [** When a the results of a GET operation is received, the `Twin` object shall merge the properties into `this.properties.desired`. **]**
-
-**SRS_NODE_DEVICE_TWIN_18_036: [** When a PATCH operation is received, the `Twin` object shall merge the properties into `this.properties.desired`. **]**
-
-**SRS_NODE_DEVICE_TWIN_18_039: [** After merging a GET result, the `Twin` object shall recursively fire property changed events for every changed property. **]**
-
-**SRS_NODE_DEVICE_TWIN_18_040: [** After merging a PATCH result, the `Twin` object shall recursively fire property changed events for every changed property. **]**
-
-**SRS_NODE_DEVICE_TWIN_18_041: [** When firing a property changed event, the `Twin` object shall name the event from the property using dot notation starting with 'properties.desired.' **]**
-
-**SRS_NODE_DEVICE_TWIN_18_042: [** When firing a property changed event, the `Twin` object shall pass the changed value of the property as the event parameter **]**
-
-**SRS_NODE_DEVICE_TWIN_18_045: [** If a property is already set when a handler is added for that property, the `Twin` object shall fire a property changed event for the property. **]* 
 

--- a/device/core/devdoc/device_twin_requirements.md
+++ b/device/core/devdoc/device_twin_requirements.md
@@ -7,7 +7,7 @@ azure-iot-device.Twin provides access to the Device Twin functionaliy of IoTHub.
 
 ```typescript
 class Twin extends EventEmitter {
-  constructor(transport: Client.Transport);
+  constructor(transport: Client.Transport, retryPolicy: RetryPolicy, maxOperationTimeout: number);
   get(callback: (err: Error, twin?: Twin) => void): void;
   properties: {
     reported: {
@@ -61,6 +61,10 @@ class Twin extends EventEmitter {
 **SRS_NODE_DEVICE_TWIN_16_012: [** When a `twinDesiredPropertiesUpdates` event is emitted by the transport, the property patch passed as argument to the event handler shall be merged with the current desired properties. **]**
 
 **SRS_NODE_DEVICE_TWIN_16_013: [** Recursively for each desired property that is part of the patch received, an event named using the convention `properties.desired[.path]` shall be fired with an argument containing the value of the property. **]**
+
+### setRetryPolicy(retryPolicy: RetryPolicy): void
+
+**SRS_NODE_DEVICE_TWIN_16_014: [** the `retryPolicy` object passed to the `setRetryPolicy` method shall be used to retry any subsequent operation.  **]**
 
 
 ## Implementation notes

--- a/device/core/device.d.ts
+++ b/device/core/device.d.ts
@@ -9,3 +9,4 @@ export { DeviceMethodRequest, DeviceMethodResponse } from './lib/device_method';
 export { X509AuthenticationProvider } from './lib/x509_authentication_provider';
 export { SharedAccessSignatureAuthenticationProvider } from './lib/sas_authentication_provider';
 export { SharedAccessKeyAuthenticationProvider } from './lib/sak_authentication_provider';
+export { Twin, TwinProperties } from './lib/twin';

--- a/device/core/device.js
+++ b/device/core/device.js
@@ -53,4 +53,6 @@ module.exports = {
   X509AuthenticationProvider: require('./lib/x509_authentication_provider').X509AuthenticationProvider,
   SharedAccessSignatureAuthenticationProvider: require('./lib/sas_authentication_provider').SharedAccessSignatureAuthenticationProvider,
   SharedAccessKeyAuthenticationProvider: require('./lib/sak_authentication_provider').SharedAccessKeyAuthenticationProvider,
+  Twin: require('./lib/twin').Twin,
+  TwinProperties: require('./lib/twin').TwinProperties
 };

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec \"test/**/_*_test*.js\"",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 85 --lines 96 --functions 91"
+    "check-cover": "istanbul check-coverage --statements 96 --branches 88 --lines 98 --functions 93"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec \"test/**/_*_test*.js\"",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 83 --lines 96 --functions 91"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 85 --lines 96 --functions 91"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/core/src/twin.ts
+++ b/device/core/src/twin.ts
@@ -8,9 +8,15 @@ import * as traverse from 'traverse';
 import * as dbg from 'debug';
 const debug = dbg('azure-iot-device:Twin');
 
-import { errors } from 'azure-iot-common';
-import { translateError } from './twin_errors';
 import { Client } from './client';
+
+/**
+ * Contains the desired and reported properties for the Twin.
+ */
+export interface TwinProperties {
+  desired: { [key: string]: any };
+  reported: { [key: string]: any };
+}
 
 /**
  * A Device Twin is document describing the state of a device that is stored by an Azure IoT hub and is available even if the device is offline.
@@ -26,21 +32,14 @@ import { Client } from './client';
  *
  */
 export class Twin extends EventEmitter {
-  static timeout: number = 120000;
   static errorEvent: string = 'error';
-  static subscribedEvent: string = 'subscribed';
-  static responseEvent: string = 'response';
-  static postEvent: string = 'post';
   static desiredPath: string = 'properties.desired';
 
   /**
    * The desired and reported properties dictionnaries (respectively in `properties.desired` and `properties.reported`).
    */
-  properties: any; // TODO: need type
-
-  private _rid: number;
-  private _client: Client;
-  private _receiver: any; // TODO: need type
+  properties: TwinProperties;
+  private _transport: Client.Transport;
 
   /**
    * The constructor should not be used directly and instead the SDK user should use the {@link Client#getTwin} method to obtain a valid `Twin` object.
@@ -48,158 +47,59 @@ export class Twin extends EventEmitter {
    * @private
    * @param client The device client to use in order to communicate with the Azure IoT hub.
    */
-  constructor(client: Client) {
+  constructor(transport: Client.Transport) {
     super();
-    this._client = client;
-    this._rid = 4200; // arbitrary starting value.
+    this._transport = transport;
+    this.on('newListener', this._handleNewListener.bind(this));
+    /*Codes_SRS_NODE_DEVICE_TWIN_16_001: [The `Twin` constructor shall subscribe to the `onDesiredPropertiesUpdate` event off the `transport` object.]*/
+    this._transport.on('twinDesiredPropertiesUpdate', this._onDesiredPropertiesUpdate.bind(this));
   }
 
-  private _connectSubscribeAndGetProperties(done: (err?: Error, result?: Twin) => void): void {
-    const self = this;
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_004: [** `fromDeviceClient` shall call `getTwinReceiver` on the protocol object to get a twin receiver. **]**  */
-    this._client._transport.getTwinReceiver((err, receiver) => {
+  /**
+   * Gets the whole twin from the service.
+   *
+   * @param callback function that shall be called back with either the twin or an error if the transport fails to retrieve the twin.
+   */
+  get(callback: (err: Error, twin?: Twin) => void): void {
+    /*Codes_SRS_NODE_DEVICE_TWIN_16_002: [The `get` method shall call the `getTwin` method of the `Transport` object with a callback.]*/
+    this._transport.getTwin((err, twinProperties) => {
       if (err) {
-        done(err);
+        /*Codes_SRS_NODE_DEVICE_TWIN_16_003: [If the callback passed to the `getTwin` method is called with an error, the `callback` passed to the call to the `get` method shall be called with that error.]*/
+        callback(err);
       } else {
-        self._receiver = receiver;
-
-        self._subscribe((err) => {
-          if (err) {
-            done(err);
-          } else {
-            self._getPropertiesFromService((err) => {
-              /* Codes_SRS_NODE_DEVICE_TWIN_18_043: [** If the GET operation fails, `fromDeviceClient` shall call the done method with the error object in the first parameter **]** */
-              done(err, self);
-            });
-          }
-        });
+        this._clearCachedProperties();
+        /*Codes_SRS_NODE_DEVICE_TWIN_16_004: [If the callback passed to the `getTwin` method is called with no error and a `TwinProperties` object, these properties shall be merged with the current instance properties.]*/
+        this._mergePatch(this.properties.desired, twinProperties.desired);
+        this._mergePatch(this.properties.reported, twinProperties.reported);
+        /*Codes_SRS_NODE_DEVICE_TWIN_16_006: [For each desired property that is part of the `TwinProperties` object received, an event named after the path to this property shall be fired.]*/
+        this._fireChangeEvents(this.properties.desired);
+        /*Codes_SRS_NODE_DEVICE_TWIN_16_005: [Once the properties have been merged the `callback` method passed to the call to `get` shall be called with a first argument that is `null` and a second argument that is the current `Twin` instance (`this`).]*/
+        callback(null, this);
       }
     });
   }
 
-  /* Codes_SRS_NODE_DEVICE_TWIN_18_031: [** `fromDeviceClient` shall subscribe to the response topic **]** */
-  /* Codes_SRS_NODE_DEVICE_TWIN_18_032: [** `fromDeviceClient` shall subscribe to the desired property patch topic **]** */
-  private _subscribe(done: (err?: Error) => void): void {
-    const twin = this;
-    const receiver = twin._receiver;
-    const topics = [
-      {
-        topicName : Twin.responseEvent,
-        subscribed : false,
-        handler : () => {
-          debug('Got Twin response');
-        }
-      },
-      {
-        topicName : Twin.postEvent,
-        subscribed : false,
-        handler : twin._onServicePost.bind(this)
-      }
-    ];
-
-    let timeout = null;
-    function cleanupAndReturn(err?: Error): void {
-      clearTimeout(timeout);
-      timeout = null;
-      /* Codes_SRS_NODE_DEVICE_TWIN_18_012: [** `fromDeviceClient` shall remove the handlers for both the `subscribed` and `error` events before calling the `done` callback. **]**   */
-      receiver.removeListener(Twin.subscribedEvent, handleSubscribed);
-      receiver.removeListener(Twin.errorEvent, handleError);
-      done(err);
-    }
-
-    function handleSubscribed(obj: any): void{
-      if (topics.some((topic) => {
-        if (topic.topicName === obj.eventName) {
-          topic.subscribed = true;
-          return true;
-        }
-      })) {
-        if (topics.every((topic) => {
-          return topic.subscribed;
-        })) {
-          cleanupAndReturn(null);
-        }
-      }
-    }
-
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_010: [** `fromDeviceClient` shall call the `done` callback passing  the first error that is returned from `error` event on the twinReceiver. **]**  */
-    let errAlreadySent = false;
-    function handleError(topic: string): void {
-      if (!errAlreadySent) {
-        errAlreadySent = true;
-        cleanupAndReturn(new errors.ServiceUnavailableError('failed to subscribe to ' + topic));
-      }
-    }
-
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_007: [** `fromDeviceClient` shall add handlers for the both the `subscribed` and `error` events on the twinReceiver **]**  */
-    receiver.on(Twin.subscribedEvent, handleSubscribed);
-    receiver.on(Twin.errorEvent, handleError);
-
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_009: [** `fromDeviceClient` shall call the `done` callback passing a `TimeoutError` if it has not received all necessary `subscribed` events within `Twin.timeout` milliseconds. **]** */
-    timeout = setTimeout(() => {
-      cleanupAndReturn(new errors.TimeoutError('subscription to twin messages timed out'));
-    }, Twin.timeout);
-
-    topics.forEach((topic) => {
-      receiver.on(topic.topicName, topic.handler);
-    });
+  private _enableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void {
+    this._transport.enableTwinDesiredPropertiesUpdates(callback);
   }
 
-  private _sendTwinRequest(method: string, resource: string, properties: any, body: any, done: (err?: Error, result?: any) => void): void {
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_014: [** `_sendTwinRequest` shall use an arbitrary starting `rid` and increment it by one for every call to `_sendTwinRequest` **]**  */
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_017: [** `_sendTwinRequest` shall put the `rid` value into the `properties` object that gets passed to `sendTwinRequest` on the transport **]**  */
-    let propCopy = JSON.parse(JSON.stringify(properties));
-    propCopy.$rid = this._rid;
-    this._rid++;
-
-    const self = this;
-
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_021: [** Before calling `done`, `_sendTwinRequest` shall remove the handler for the `response` event **]**  */
-    let timeout = null;
-    function cleanupAndReturn (err?: Error, body?: any): void {
-      clearTimeout(timeout);
-      timeout = null;
-      self._receiver.removeListener('response', handleResponse);
-      done(err, body);
-    }
-
-    function handleResponse (resp: any): void {
-      /* Codes_SRS_NODE_DEVICE_TWIN_18_018: [** The response handler shall ignore any messages that dont have an `rid` that matches the `rid` of the request **]**   */
-      if (resp.$rid.toString() === propCopy.$rid.toString()) {
-        /* Codes_SRS_NODE_DEVICE_TWIN_18_019: [** `_sendTwinRequest` shall call `done` with `err`=`null` if the response event returns `status`===200 or 204 **]**   */
-        if (resp.status.toString() === '200' || resp.status.toString() === '204') {
-        cleanupAndReturn(null, resp.body);
-        } else {
-          /* Codes_SRS_NODE_DEVICE_TWIN_18_020: [** `_sendTwinRequest` shall call `done` with an `err` value translated using `translateError`**]**  */
-          cleanupAndReturn(translateError(resp, resp.status));
-        }
-      }
-    }
-
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_015: [** `_sendTwinRequest` shall add a handler for the `response` event on the twinReceiver object.  **]** */
-    this._receiver.on('response', handleResponse);
-
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_022: [** If the response doesnt come within `Twin.timeout` milliseconds, `_sendTwinRequest` shall call `done` with `err`=`TimeoutError` **]**   */
-    timeout = setTimeout(() => {
-      cleanupAndReturn(new errors.TimeoutError('message timed out'), null);
-    }, Twin.timeout);
-
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_016: [** `_sendTwinRequest` shall use the `sendTwinRequest` method on the transport to send the request **]**  */
-    this._client._transport.sendTwinRequest(method, resource, propCopy, body);
-  }
-
+  // Note: Since we currently don't keep track of listeners, so we don't "disable" the twin properties updates when no one is listening.
+  // This is a shortcoming that should be fixed.
+  // private _disableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void {
+  //   this._transport.disableTwinDesiredPropertiesUpdates(callback);
+  // }
 
   private _updateReportedProperties(state: any, done: (err?: Error) => void): void {
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_025: [** `properties.reported.update` shall use _sendTwinRequest to send the patch object to the service. **]**  */
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_026: [** When calling `_sendTwinRequest`, `properties.reported.update` shall pass `method`='PATCH', `resource`='/properties/reported/', `properties`={}, and `body`=the `body` parameter passed in to `reportState` as a string. **]**    */
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_027: [** `properties.reported.update` shall call `done` with the results from `_sendTwinRequest` **]**  */
-    const self = this;
-    this._sendTwinRequest('PATCH', '/properties/reported/', {}, JSON.stringify(state), (err) => {
-      /* Codes_SRS_NODE_DEVICE_TWIN_18_033: [** If `_sendTwinRequest` fails, `properties.reported.update` shall not merge the contents of the patch object into `properties.reported` **]** */
+    /*Codes_SRS_NODE_DEVICE_TWIN_16_007: [The `update` method shall call the `updateReportedProperties` method of the `Transport` object and pass it the patch object and a callback accepting an error as argument.]*/
+    this._transport.updateTwinReportedProperties(state, (err) => {
       if (err) {
+        /*Codes_SRS_NODE_DEVICE_TWIN_16_008: [If the callback passed to the transport is called with an error, the `callback` argument of the `update` method shall be called with that error.]*/
         done(err);
       } else {
-        self._mergePatch(self.properties.reported, state);
+        /*Codes_SRS_NODE_DEVICE_TWIN_18_031: [If the callback passed to the transport is called with no error, the  `properties.reported.update` shall merge the contents of the patch object into `properties.reported`]*/
+        /*Codes_SRS_NODE_DEVICE_TWIN_18_032: [When merging the patch, if any properties are set to `null`, `properties.reported.update` shall delete that property from `properties.reported`.]*/
+        this._mergePatch(this.properties.reported, state);
+        /*Codes_SRS_NODE_DEVICE_TWIN_16_009: [Once the properties have been merged the `callback` argument of the `update` method shall be called with no argument.]*/
         done();
       }
     });
@@ -230,25 +130,6 @@ export class Twin extends EventEmitter {
     };
   }
 
-  /* Codes_SRS_NODE_DEVICE_TWIN_18_044: [** `fromDeviceClient` shall do a GET call to retrieve desired properties from the service. **]** */
-  private _getPropertiesFromService(done: (err?: Error) => void): void {
-    const self = this;
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_034: [** `fromDeviceClient` shall ignore any PATCH operations that arrive before the GET returns **]** */
-    this._clearCachedProperties();
-    this._sendTwinRequest('GET', '/', {}, ' ', (err, body) => {
-      if (err) {
-        done(err);
-      } else {
-        /* Codes_SRS_NODE_DEVICE_TWIN_18_035: [** When a the results of a GET operation is received, the `Twin` object shall merge the properties into `this.properties.desired`. **]** */
-        const props = JSON.parse(body.toString('ascii'));
-        self._mergePatch(self.properties.desired, props.desired);
-        self._mergePatch(self.properties.reported, props.reported);
-        self._fireChangeEvents(self.properties.desired);
-        done();
-      }
-    });
-  }
-
   /* Codes_SRS_NODE_DEVICE_TWIN_18_039: [** After merging a GET result, the `Twin` object shall recursively fire property changed events for every changed property. **]** */
   /* Codes_SRS_NODE_DEVICE_TWIN_18_040: [** After merging a PATCH result, the `Twin` object shall recursively fire property changed events for every changed property. **]** */
   private _fireChangeEvents(desiredProperties: any): void {
@@ -264,10 +145,10 @@ export class Twin extends EventEmitter {
     });
   }
 
-  /* Codes_SRS_NODE_DEVICE_TWIN_18_036: [** When a PATCH operation is received, the `Twin` object shall merge the properties into `this.properties.desired`. **]** */
-  private _onServicePost(body: any): void {
-    const patch = JSON.parse(body.toString('ascii'));
+  private _onDesiredPropertiesUpdate(patch: any): void {
+    /*Codes_SRS_NODE_DEVICE_TWIN_16_012: [When a `twinDesiredPropertiesUpdates` event is emitted by the transport, the property patch passed as argument to the event handler shall be merged with the current desired properties.]*/
     this._mergePatch(this.properties.desired, patch);
+    /*Codes_SRS_NODE_DEVICE_TWIN_16_013: [Recursively for each desired property that is part of the patch received, an event named using the convention `properties.desired[.path]` shall be fired with an argument containing the value of the protperty.]*/
     this._fireChangeEvents(patch);
   }
 
@@ -276,47 +157,23 @@ export class Twin extends EventEmitter {
     const self = this;
     if (eventName.indexOf(Twin.desiredPath) === 0) {
       const propertyValue = _.at(this, eventName)[0];
+      /*Codes_SRS_NODE_DEVICE_TWIN_18_045: [If a property is already set when a handler is added for that property, the `Twin` object shall fire a property changed event for the property.]*/
       if (propertyValue) {
         process.nextTick(() => {
           self.emit(eventName, propertyValue);
         });
       }
-    }
-  }
 
-  /**
-   * @private
-   * @method          module:azure-iot-device.Twin#fromDeviceClient
-   * @description     Get a Twin object for the given client connection. This is meant to be called by the device client, not by the SDK user who should be using {@link Client#getTwin}.
-   * @static
-   *
-   * @param  {Object}         client  The [client]{@link module:azure-iot-device.Client} object that this Twin object is associated with.
-   * @param  {Function}       done  the callback to be invoked when this function completes.
-   *
-   * @throws {ReferenceError} One of the required parameters is falsy
-   */
-  static fromDeviceClient(client: Client, done: (err?: Error, result?: Twin) => void): void {
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_002: [** `fromDeviceclient` shall throw `ReferenceError` if the `client` object is falsy **]** */
-    if (!client) {
-      throw new ReferenceError('client parameter is required');
-    }
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_030: [** `fromDeviceclient` shall throw `ReferenceError` if the `done` argument is falsy **]** */
-    if (!done) {
-      throw new ReferenceError('done parameter is required');
-    }
-
-    /* Codes_SRS_NODE_DEVICE_TWIN_18_028: [** if `fromDeviceClient` has previously been called for this client, it shall perform a GET operation and return the same object **]** */
-    if (client._twin) {
-      client._twin._getPropertiesFromService((err) => {
-          done(err,client._twin);
-        });
-    } else {
-      /* Codes_SRS_NODE_DEVICE_TWIN_18_029: [** if `fromDeviceClient` is called with 2 different `client`s, it shall return 2 unique `Twin` objects **]** */
-      /* Codes_SRS_NODE_DEVICE_TWIN_18_003: [** `fromDeviceClient` shall allocate a new `Twin` object **]**  */
-      const twin = new Twin(client);
-      twin.on('newListener', twin._handleNewListener.bind(twin));
-      client._twin = twin;
-      twin._connectSubscribeAndGetProperties(done);
+      /*Codes_SRS_NODE_DEVICE_TWIN_16_010: [When a listener is added for an event name starting with `properties.desired` the `enableTwinDesiredPropertiesUpdates` method of the `Transport` object shall be called with a callback function accepting an optional error argument.]*/
+      this._enableTwinDesiredPropertiesUpdates((err) => {
+        if (err) {
+          debug('error enabling desired properties updates: ' + err.toString());
+          /*Codes_SRS_NODE_DEVICE_TWIN_16_011: [If the callback passed to the transport is called with an error, that error shall be emitted by the Twin object.]*/
+          this.emit('error', err);
+        } else {
+          debug('desired properties updates enabled');
+        }
+      });
     }
   }
 }

--- a/device/core/src/twin.ts
+++ b/device/core/src/twin.ts
@@ -8,6 +8,7 @@ import * as traverse from 'traverse';
 import * as dbg from 'debug';
 const debug = dbg('azure-iot-device:Twin');
 
+import { RetryPolicy, RetryOperation } from 'azure-iot-common';
 import { Client } from './client';
 
 /**
@@ -39,7 +40,10 @@ export class Twin extends EventEmitter {
    * The desired and reported properties dictionnaries (respectively in `properties.desired` and `properties.reported`).
    */
   properties: TwinProperties;
+  desiredPropertiesUpdatesEnabled: boolean;
   private _transport: Client.Transport;
+  private _retryPolicy: RetryPolicy;
+  private _maxOperationTimeout: number;
 
   /**
    * The constructor should not be used directly and instead the SDK user should use the {@link Client#getTwin} method to obtain a valid `Twin` object.
@@ -47,9 +51,12 @@ export class Twin extends EventEmitter {
    * @private
    * @param client The device client to use in order to communicate with the Azure IoT hub.
    */
-  constructor(transport: Client.Transport) {
+  constructor(transport: Client.Transport, retryPolicy: RetryPolicy, maxTimeout: number) {
     super();
     this._transport = transport;
+    this._retryPolicy = retryPolicy;
+    this._maxOperationTimeout = maxTimeout;
+    this.desiredPropertiesUpdatesEnabled = false;
     this.on('newListener', this._handleNewListener.bind(this));
     /*Codes_SRS_NODE_DEVICE_TWIN_16_001: [The `Twin` constructor shall subscribe to the `onDesiredPropertiesUpdate` event off the `transport` object.]*/
     this._transport.on('twinDesiredPropertiesUpdate', this._onDesiredPropertiesUpdate.bind(this));
@@ -61,26 +68,46 @@ export class Twin extends EventEmitter {
    * @param callback function that shall be called back with either the twin or an error if the transport fails to retrieve the twin.
    */
   get(callback: (err: Error, twin?: Twin) => void): void {
-    /*Codes_SRS_NODE_DEVICE_TWIN_16_002: [The `get` method shall call the `getTwin` method of the `Transport` object with a callback.]*/
-    this._transport.getTwin((err, twinProperties) => {
-      if (err) {
-        /*Codes_SRS_NODE_DEVICE_TWIN_16_003: [If the callback passed to the `getTwin` method is called with an error, the `callback` passed to the call to the `get` method shall be called with that error.]*/
-        callback(err);
-      } else {
-        this._clearCachedProperties();
-        /*Codes_SRS_NODE_DEVICE_TWIN_16_004: [If the callback passed to the `getTwin` method is called with no error and a `TwinProperties` object, these properties shall be merged with the current instance properties.]*/
-        this._mergePatch(this.properties.desired, twinProperties.desired);
-        this._mergePatch(this.properties.reported, twinProperties.reported);
-        /*Codes_SRS_NODE_DEVICE_TWIN_16_006: [For each desired property that is part of the `TwinProperties` object received, an event named after the path to this property shall be fired.]*/
-        this._fireChangeEvents(this.properties.desired);
-        /*Codes_SRS_NODE_DEVICE_TWIN_16_005: [Once the properties have been merged the `callback` method passed to the call to `get` shall be called with a first argument that is `null` and a second argument that is the current `Twin` instance (`this`).]*/
-        callback(null, this);
-      }
-    });
+    const retryOp = new RetryOperation(this._retryPolicy, this._maxOperationTimeout);
+    retryOp.retry((opCallback) => {
+      /*Codes_SRS_NODE_DEVICE_TWIN_16_002: [The `get` method shall call the `getTwin` method of the `Transport` object with a callback.]*/
+      this._transport.getTwin((err, twinProperties) => {
+        if (err) {
+          /*Codes_SRS_NODE_DEVICE_TWIN_16_003: [If the callback passed to the `getTwin` method is called with an error, the `callback` passed to the call to the `get` method shall be called with that error.]*/
+          opCallback(err);
+        } else {
+          this._clearCachedProperties();
+          /*Codes_SRS_NODE_DEVICE_TWIN_16_004: [If the callback passed to the `getTwin` method is called with no error and a `TwinProperties` object, these properties shall be merged with the current instance properties.]*/
+          this._mergePatch(this.properties.desired, twinProperties.desired);
+          this._mergePatch(this.properties.reported, twinProperties.reported);
+          /*Codes_SRS_NODE_DEVICE_TWIN_16_006: [For each desired property that is part of the `TwinProperties` object received, an event named after the path to this property shall be fired.]*/
+          this._fireChangeEvents(this.properties.desired);
+          /*Codes_SRS_NODE_DEVICE_TWIN_16_005: [Once the properties have been merged the `callback` method passed to the call to `get` shall be called with a first argument that is `null` and a second argument that is the current `Twin` instance (`this`).]*/
+          opCallback(null, this);
+        }
+      });
+    }, callback);
   }
 
-  private _enableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void {
-    this._transport.enableTwinDesiredPropertiesUpdates(callback);
+  /**
+   * @private
+   */
+  setRetryPolicy(policy: RetryPolicy): void {
+    /*Codes_SRS_NODE_DEVICE_TWIN_16_014: [the `retryPolicy` object passed to the `setRetryPolicy` method shall be used to retry any subsequent operation.]*/
+    this._retryPolicy = policy;
+  }
+
+  /**
+   * @private
+   */
+  enableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void {
+    const retryOp = new RetryOperation(this._retryPolicy, this._maxOperationTimeout);
+    retryOp.retry((opCallback) => {
+      this._transport.enableTwinDesiredPropertiesUpdates((err) => {
+        this.desiredPropertiesUpdatesEnabled = !err;
+        opCallback(err);
+      });
+    }, callback);
   }
 
   // Note: Since we currently don't keep track of listeners, so we don't "disable" the twin properties updates when no one is listening.
@@ -90,19 +117,22 @@ export class Twin extends EventEmitter {
   // }
 
   private _updateReportedProperties(state: any, done: (err?: Error) => void): void {
-    /*Codes_SRS_NODE_DEVICE_TWIN_16_007: [The `update` method shall call the `updateReportedProperties` method of the `Transport` object and pass it the patch object and a callback accepting an error as argument.]*/
-    this._transport.updateTwinReportedProperties(state, (err) => {
-      if (err) {
-        /*Codes_SRS_NODE_DEVICE_TWIN_16_008: [If the callback passed to the transport is called with an error, the `callback` argument of the `update` method shall be called with that error.]*/
-        done(err);
-      } else {
-        /*Codes_SRS_NODE_DEVICE_TWIN_18_031: [If the callback passed to the transport is called with no error, the  `properties.reported.update` shall merge the contents of the patch object into `properties.reported`]*/
-        /*Codes_SRS_NODE_DEVICE_TWIN_18_032: [When merging the patch, if any properties are set to `null`, `properties.reported.update` shall delete that property from `properties.reported`.]*/
-        this._mergePatch(this.properties.reported, state);
-        /*Codes_SRS_NODE_DEVICE_TWIN_16_009: [Once the properties have been merged the `callback` argument of the `update` method shall be called with no argument.]*/
-        done();
-      }
-    });
+    const retryOp = new RetryOperation(this._retryPolicy, this._maxOperationTimeout);
+    retryOp.retry((opCallback) => {
+      /*Codes_SRS_NODE_DEVICE_TWIN_16_007: [The `update` method shall call the `updateReportedProperties` method of the `Transport` object and pass it the patch object and a callback accepting an error as argument.]*/
+      this._transport.updateTwinReportedProperties(state, (err) => {
+        if (err) {
+          /*Codes_SRS_NODE_DEVICE_TWIN_16_008: [If the callback passed to the transport is called with an error, the `callback` argument of the `update` method shall be called with that error.]*/
+          opCallback(err);
+        } else {
+          /*Codes_SRS_NODE_DEVICE_TWIN_18_031: [If the callback passed to the transport is called with no error, the  `properties.reported.update` shall merge the contents of the patch object into `properties.reported`]*/
+          /*Codes_SRS_NODE_DEVICE_TWIN_18_032: [When merging the patch, if any properties are set to `null`, `properties.reported.update` shall delete that property from `properties.reported`.]*/
+          this._mergePatch(this.properties.reported, state);
+          /*Codes_SRS_NODE_DEVICE_TWIN_16_009: [Once the properties have been merged the `callback` argument of the `update` method shall be called with no argument.]*/
+          opCallback();
+        }
+      });
+    }, done);
   }
 
   /* Codes_SRS_NODE_DEVICE_TWIN_18_031: [** `properties.reported.update` shall merge the contents of the patch object into `properties.reported` **]** */
@@ -165,7 +195,7 @@ export class Twin extends EventEmitter {
       }
 
       /*Codes_SRS_NODE_DEVICE_TWIN_16_010: [When a listener is added for an event name starting with `properties.desired` the `enableTwinDesiredPropertiesUpdates` method of the `Transport` object shall be called with a callback function accepting an optional error argument.]*/
-      this._enableTwinDesiredPropertiesUpdates((err) => {
+      this.enableTwinDesiredPropertiesUpdates((err) => {
         if (err) {
           debug('error enabling desired properties updates: ' + err.toString());
           /*Codes_SRS_NODE_DEVICE_TWIN_16_011: [If the callback passed to the transport is called with an error, that error shall be emitted by the Twin object.]*/

--- a/device/core/test/_twin_test.js
+++ b/device/core/test/_twin_test.js
@@ -11,583 +11,228 @@ var errors = require('azure-iot-common').errors;
 var sinon = require('sinon');
 var _ = require('lodash');
 
-
-var FakeReceiver = function() {
-
-  EventEmitter.call(this);
-
-  var self = this;
-  this.forceError = false;
-  this.successfulSubscription = true;
-
-   this._handleNewListener = function(eventname) {
-    if (EventEmitter.listenerCount(self, eventname) === 0)
-    {
-      process.nextTick(function() {
-        if (eventname === Twin.responseEvent || eventname === Twin.postEvent) {
-          if (self.forceError) {
-            self.emit('error', new Error('failed to subscribe to ' + eventname))                               ;
-          } else if (self.successfulSubscription) {
-            self.emit('subscribed', {eventName: self.fakeSubscriptionName || eventname});
-          }
-          // else time out
-        }
-      });
-    }
-  };
-  this.on("newListener", this._handleNewListener);
-};
-util.inherits(FakeReceiver, EventEmitter);
-
-var FakeTransport = function(receiver) {
-  var self = this;
-  this.status=200;
-  this.getResponse = '{}';
-
-  if (receiver) {
-    this._receiver = receiver;
-  } else {
-    this._receiver = new FakeReceiver();
-  }
-
-  this.getReceiver = function(done) {
-    done(null, new EventEmitter());
-  };
-
-  this.getTwinReceiver = function(done) {
-    done(null, this._receiver);
-  };
-
-  this.sendTwinRequest = function(method, resource, properties, body, done)  {
-    void(method, resource, properties, body);
-
-    process.nextTick(function() {
-      var response = {
-        'status' : self.status,
-        '$rid' : self.responseId || properties.$rid,
-        'body' : method === 'GET' ? self.getResponse : '{}'
-      };
-      self._receiver.emit('response', response);
-    });
-    if (done) {
-      done();
-    }
-  };
-};
-
-
-
-var FakeClient = function(transport) {
-  EventEmitter.call(this);
-  if (transport) {
-    this._transport = transport;
-  } else {
-    this._transport = new FakeTransport();
-  }
-};
-util.inherits(FakeClient, EventEmitter);
-
-Twin.timeout = 10;
-
 describe('Twin', function () {
-  describe('fromDeviceClient', function () {
+  var fakeTransport, fakeTwin;
 
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_002: [** `fromDeviceclient` shall throw `ReferenceError` if the `client` object is falsy **]** */
-    it('throws if client is falsy', function () {
-      assert.throws(function() { Twin.fromDeviceClient(null, function() {}); }, ReferenceError);
-    });
+  beforeEach(function () {
+    fakeTwin = {
+      desired: {
+        key: 'value'
+      },
+      reported: {
+        key: 'value'
+      }
+    };
 
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_030: [** `fromDeviceclient` shall throw `ReferenceError` if the `done` argument is falsy **]** */
-    it('throws if done is falsy', function () {
-      assert.throws(function() { Twin.fromDeviceClient({}); }, ReferenceError);
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_003: [** `fromDeviceClient` shall allocate a new `Twin` object **]**  */
-    it('Allocates a new twin object', function (done) {
-      var client = new FakeClient();
-      Twin.fromDeviceClient(client, function(err, obj) {
-        if (err) return done(err);
-        assert.instanceOf(obj, Twin);
-        done();
-      });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_044: [** `fromDeviceClient` shall do a GET call to retrieve desired properties from the service. **]** */
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_028: [** if `fromDeviceClient` has previously been called for this client, it shall perform a GET operation and return the same object **]** */
-    it('returns the same object if called twice', function (done) {
-      var client = new FakeClient();
-      sinon.spy(client._transport, "sendTwinRequest");
-      Twin.fromDeviceClient(client, function(err, obj1) {
-        assert(client._transport.sendTwinRequest.withArgs('GET').calledOnce);
-        if (err) return done(err);
-        Twin.fromDeviceClient(client, function(err, obj2) {
-          assert(client._transport.sendTwinRequest.withArgs('GET').calledTwice);
-          assert.equal(obj1, obj2);
-          done();
-        });
-      });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_029: [** if `fromDeviceClient` is called with 2 different `client`s, it shall return 2 unique `Twin` objects **]** */
-    it('returns a unique twin per client', function (done) {
-      var client1 = new FakeClient();
-      var client2 = new FakeClient();
-      Twin.fromDeviceClient(client1, function(err, obj1) {
-        if (err) return done(err);
-        Twin.fromDeviceClient(client2, function(err, obj2) {
-          assert.notEqual(obj1, obj2);
-          done();
-        });
-      });
-    });
-
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_004: [** `fromDeviceClient` shall call `getTwinReceiver` on the protocol object to get a twin receiver. **]**  */
-    it('calls getTwinReceiver', function (done) {
-      var client = new FakeClient();
-      Twin.fromDeviceClient(client, function(err, obj) {
-        if (err) return done(err);
-        assert.instanceOf(obj._receiver, FakeReceiver);
-        done();
-      });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_007: [** `fromDeviceClient` shall add handlers for the both the `subscribed` and `error` events on the twinReceiver **]**  */
-    it('adds correct handlers', function (done) {
-      var receiver = new FakeReceiver();
-      receiver.removeListener("newListener", receiver._handleNewListener);
-      var handleNewListener = sinon.spy(receiver,"_handleNewListener");
-      receiver.on("newListener", receiver._handleNewListener);
-      var transport = new FakeTransport(receiver);
-      var client = new FakeClient(transport);
-      Twin.fromDeviceClient(client, function(err) {
-        if (err) return done(err);
-        assert(handleNewListener.withArgs('subscribed').calledOnce);
-        assert(handleNewListener.withArgs('error').calledOnce);
-        /* Tests_SRS_NODE_DEVICE_TWIN_18_031: [** `fromDeviceClient` shall subscribe to the response topic **]** */
-        assert(handleNewListener.withArgs('response').called);
-        /* Tests_SRS_NODE_DEVICE_TWIN_18_032: [** `fromDeviceClient` shall subscribe to the desired property patch topic **]** */
-        assert(handleNewListener.withArgs('post').called);
-        done();
-      });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_009: [** `fromDeviceClient` shall call the `done` callback passing a `TimeoutError` if it has not received all necessary `subscribed` events within `Twin.timeout` milliseconds. **]** */
-    it('returns timeout correctly', function(done) {
-      var receiver = new FakeReceiver();
-      receiver.successfulSubscription = false;
-      var transport = new FakeTransport(receiver);
-      var client = new FakeClient(transport);
-      Twin.fromDeviceClient(client, function(err) {
-        assert.instanceOf(err, errors.TimeoutError);
-        done();
-      });
-    });
-
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_010: [** `fromDeviceClient` shall call the `done` callback passing  the first error that is returned from `error` event on the twinReceiver. **]**  */
-    it('returns error on subscription failure', function (done) {
-      var receiver = new FakeReceiver();
-      receiver.forceError = true;
-      var transport = new FakeTransport(receiver);
-      var client = new FakeClient(transport);
-      Twin.fromDeviceClient(client, function(err) {
-        assert.instanceOf(err,Error);
-        done();
-      });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_012: [** `fromDeviceClient` shall remove the handlers for both the `subscribed` and `error` events before calling the `done` callback. **]**   */
-    it('cleans up handlers before calling done', function (done) {
-      var client = new FakeClient();
-      Twin.fromDeviceClient(client, function(err, obj) {
-        if (err) return done(err);
-        assert.equal(EventEmitter.listenerCount(obj,'subscribed'),0);
-        assert.equal(EventEmitter.listenerCount(obj,'error'),0);
-        done();
-      });
-    });
-
-    it('gracefully handles getTwinReceiver failures', function(done) {
-      var client = new FakeClient();
-      client._transport.getTwinReceiver = function(done) {
-        done(new errors.TimeoutError());
-      };
-      Twin.fromDeviceClient(client, function(err) {
-        assert.instanceOf(err, errors.TimeoutError);
-        done();
-      });
-    });
-
-    it ('ignores unkonwn subscription events', function(done) {
-      var client = new FakeClient();
-      client._transport._receiver.fakeSubscriptionName = 'bogus';
-      Twin.fromDeviceClient(client, function(err) {
-        assert.instanceOf(err, errors.TimeoutError);
-        done();
-      });
-    });
-
-    it ('relies on clearTimeout(null) not excepting or crashing', function(done) {
-      clearTimeout(null);
-      done();
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_043: [** If the GET operation fails, `fromDeviceClient` shall call the done method with the error object in the first parameter **]** */
-    it('fails when the GET fails', function(done) {
-      var errorToReturn = new Error();
-      var client = new FakeClient();
-      var oldFunction = Twin.prototype._sendTwinRequest;
-      Twin.prototype._sendTwinRequest = function(method, resource, properties, body, done) {
-        if (method === "GET") {
-          done(errorToReturn);
-        } else {
-          oldFunction(method, resource, properties, body, done);
-        }
-      };
-      Twin.fromDeviceClient(client, function(err) {
-        Twin.prototype._sendTwinRequest = oldFunction;
-        assert.equal(err, errorToReturn);
-        done();
-      });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_035: [** When a the results of a GET operation is received, the `Twin` object shall merge the properties into `this.properties.desired`. **]** */
-    it('fires property changed events recursively', function(done) {
-      var client = new FakeClient();
-
-      var patch = {
-        desired : {
-          foo : {
-            bar : 1
-          },
-          baz : 1
-        }
-      };
-
-      client._transport.sendTwinRequest = function(method, resource, properties, body, done)  {
-        void(method, resource, properties, body);
-
-        process.nextTick(function() {
-          var response = {
-            'status' : 200,
-            '$rid' : properties.$rid,
-            'body' : JSON.stringify(patch)
-          };
-          client._transport._receiver.emit('response', response);
-        });
-
-        if (done) {
-          done();
-        }
-      };
-
-      Twin.fromDeviceClient(client, function(err, twin) {
-        if (err) return done(err);
-
-        var propArray = [
-          'desired',
-          'desired.foo',
-          'desired.foo.bar',
-          'desired.baz'
-        ];
-
-        propArray.forEach(function(prop) {
-          assert.deepEqual(_.at(twin.properties, prop), _.at(patch, prop));
-        });
-
-        done();
-
-
-      });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_045: [** If a property is already set when a handler is added for that property, the `Twin` object shall fire a property changed event for the property. **]*  */
-    it ('fires events if the property is already set when the handler is added', function(done) {
-      var client = new FakeClient();
-      client._transport.getResponse = JSON.stringify({desired : { foo : 42 }});
-      Twin.fromDeviceClient(client, function(err, twin) {
-        if (err) return done(err);
-        twin.on('properties.desired.foo', function(delta) {
-          if (delta === 42) {
-            done();
-          }
-        });
-      });
-    });
-
-
+    fakeTransport = new EventEmitter();
+    fakeTransport.getTwin = sinon.stub().callsArgWith(0, null, fakeTwin);
+    fakeTransport.updateTwinReportedProperties = sinon.stub().callsArg(1);
+    fakeTransport.enableTwinDesiredPropertiesUpdates = sinon.stub().callsArg(0);
+    sinon.spy(fakeTransport, 'on');
   });
 
-  describe('_sendTwinRequest', function () {
-    var receiver;
-    var transport;
-    var client;
-    var twin;
+  describe('#constructor', function () {
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_001: [The `Twin` constructor shall subscribe to the `onDesiredPropertiesUpdate` event off the `transport` object.]*/
+    it('subscribes to the twinDesiredPropertiesUpdate event on the transport', function () {
+      var twin = new Twin(fakeTransport);
+      assert.isTrue(fakeTransport.on.calledOnce);
+      assert.isTrue(fakeTransport.on.calledWith('twinDesiredPropertiesUpdate'));
+    });
+  });
 
-    beforeEach(function(done) {
-      receiver = new FakeReceiver();
-      sinon.spy(receiver, 'on');
-      sinon.spy(receiver, 'removeListener');
-      transport = new FakeTransport(receiver);
-      client = new FakeClient(transport);
-      Twin.fromDeviceClient(client, function(err, obj) {
-        if (err) return done(err);
-        twin = obj;
-        done();
+  describe('#get', function () {
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_002: [The `get` method shall call the `getTwin` method of the `Transport` object with a callback.]*/
+    it('calls getTwin on the transpport', function () {
+      var twin = new Twin(fakeTransport);
+      twin.get(function () {});
+      assert.isTrue(fakeTransport.getTwin.calledOnce);
+    });
+
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_004: [If the callback passed to the `getTwin` method is called with no error and a `TwinProperties` object, these properties shall be merged with the current instance properties.]*/
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_005: [Once the properties have been merged the `callback` method passed to the call to `get` shall be called with a first argument that is `null` and a second argument that is the current `Twin` instance (`this`).]*/
+    it('calls its callback with the twin after it is merged', function (testCallback) {
+      var twin = new Twin(fakeTransport);
+      twin.get(function (err, twin) {
+        assert.deepEqual(twin.properties.desired, fakeTwin.desired);
+        assert.deepEqual(twin.properties.reported.key, fakeTwin.reported.key);
+        testCallback();
       });
     });
 
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_016: [** `_sendTwinRequest` shall use the `sendTwinRequest` method on the transport to send the request **]**  */
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_019: [** `_sendTwinRequest` shall call `done` with `err`=`null` if the response event returns `status`===200 or 204 **]**   */
-    it ('uses the right parameters', function(done) {
-      var sendTwinRequest = sinon.spy(client._transport, 'sendTwinRequest');
-      twin._sendTwinRequest('fake_method', 'fake_resource', {}, 'fake_body', function(err) {
-        if (err) return done(err);
-        assert(sendTwinRequest.calledOnce);
-        assert.equal(sendTwinRequest.firstCall.args[0], 'fake_method');
-        assert.equal(sendTwinRequest.firstCall.args[1], 'fake_resource');
-        assert.equal(sendTwinRequest.firstCall.args[3], 'fake_body');
-        done();
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_003: [If the callback passed to the `getTwin` method is called with an error, the `callback` passed to the call to the `get` method shall be called with that error.]*/
+    it('calls its callback with an error if the transport encounters an error', function (testCallback) {
+      var fakeError = new Error('fake');
+      fakeTransport.getTwin = sinon.stub().callsArgWith(0, fakeError);
+      var twin = new Twin(fakeTransport);
+      twin.get(function (err) {
+        assert.strictEqual(err, fakeError);
+        testCallback();
       });
     });
 
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_018: [** The response handler shall ignore any messages that dont have an `rid` that matches the `rid` of the request **]**   */
-    it ('ignores non-matching responses', function(done) {
-      transport.responseId = 10;
-      twin._sendTwinRequest('fake_method', 'fake_resource', {}, 'fake_body', function(err) {
-        assert.instanceOf(err, errors.TimeoutError);
-        done();
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_006: [For each desired property that is part of the `TwinProperties` object received, an event named after the path to this property shall be fired.]*/
+    it('fires events for the new properties that have been merged', function (testCallback) {
+      var twin = new Twin(fakeTransport);
+      var genericEventReceived = false;
+      var specificEventReceived = false;
+      twin.on('properties.desired', function (delta) {
+        assert.deepEqual(delta, fakeTwin.desired);
+        genericEventReceived = true;
+        if (genericEventReceived && specificEventReceived) {
+          testCallback();
+        }
       });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_019: [** `_sendTwinRequest` shall call `done` with `err`=`null` if the response event returns `status`===200 or 204 **]**   */
-    it ('returns success on 204', function(done) {
-      transport.status = 204;
-      twin._sendTwinRequest('fake_method', 'fake_resource', {}, 'fake_body', function(err) {
-        if (err) return done(err);
-        done();
+      twin.on('properties.desired.key', function (delta) {
+        assert.strictEqual(delta, fakeTwin.desired.key);
+        specificEventReceived = true;
+        if (genericEventReceived && specificEventReceived) {
+          testCallback();
+        }
       });
-    });
 
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_014: [** `_sendTwinRequest` shall use an arbitrary starting `rid` and increment it by one for every call to `_sendTwinRequest` **]**  */
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_017: [** `_sendTwinRequest` shall put the `rid` value into the `properties` object that gets passed to `sendTwinRequest` on the transport **]**  */
-    it ('uses and incriments request ID', function(done) {
-      var sendTwinRequest = sinon.spy(client._transport, 'sendTwinRequest');
-      twin._sendTwinRequest('fake_method', 'fake_resource', {}, 'fake_body', function(err) {
-        if (err) return done(err);
-        twin._sendTwinRequest('fake_method2', 'fake_resource2', {}, 'fake_body2', function(err) {
-          if (err) return done(err);
-          assert(sendTwinRequest.calledTwice);
-          assert.isDefined(sendTwinRequest.firstCall.args[2].$rid);
-          assert.equal(sendTwinRequest.firstCall.args[2].$rid + 1, sendTwinRequest.secondCall.args[2].$rid);
-          done();
-        });
-      });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_015: [** `_sendTwinRequest` shall add a handler for the `response` event on the twinReceiver object.  **]** */
-    it ('adds a response handler', function(done) {
-        twin._sendTwinRequest('fake_method', 'fake_resource', {}, 'fake_body', function(err) {
-          if (err) return done(err);
-          assert(receiver.on.withArgs('response').calledThrice);   // once for the empty implementation, once for the GET handler, and once for our handler
-          done();
-        });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_021: [** Before calling `done`, `_sendTwinRequest` shall remove the handler for the `response` event **]**  */
-    it ('removes the response handler', function(done) {
-        twin._sendTwinRequest('fake_method', 'fake_resource', {}, 'fake_body', function(err) {
-          if (err) return done(err);
-          assert(receiver.removeListener.withArgs('response').calledTwice); // Once for the GET handler and once for our handler
-          done();
-        });
-    });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_022: [** If the response doesnt come within `Twin.timeout` milliseconds, `_sendTwinRequest` shall call `done` with `err`=`TimeoutError` **]**   */
-    it ('returns timeout correctly', function(done) {
-      transport.sendTwinRequest = function () {};
-      twin._sendTwinRequest('fake_method', 'fake_resource', {}, 'fake_body', function(err) {
-        assert.instanceOf(err, errors.TimeoutError);
-        done();
-      });
-    });
-
-    /*Tests_SRS_NODE_DEVICE_TWIN_18_020: [** `_sendTwinRequest` shall call `done` with an `err` value translated using `translateError` **]**  */
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_003: [`translateError` shall return an `ArgumentError` if the response status code is `400`.]*/
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_004: [`translateError` shall return an `UnauthorizedError` if the response status code is `401`.]*/
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_005: [`translateError` shall return an `IotHubQuotaExceededError` if the response status code is `403`.]*/
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_006: [`translateError` shall return an `DeviceNotFoundError` if the response status code is `404`.]*/
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_007: [`translateError` shall return an `MessageTooLargeError` if the response status code is `413`.]*/
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_008: [`translateError` shall return an `InternalServerError` if the response status code is `500`.]*/
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_009: [`translateError` shall return an `ServiceUnavailableError` if the response status code is `503`.]*/
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_011: [`translateError` shall return an `ServiceUnavailableError` if the response status code is `504`.]*/
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_012: [`translateError` shall return an `ThrottlingError` if the response status code is `429`.] */
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_013: [`translateError` shall return an `InvalidEtagError` if the response status code is `412`.] */
-    /*Tests_SRS_NODE_DEVICE_TWIN_ERRORS_18_002: [If the error code is unknown, `translateError` should return a generic Javascript `Error` object.]*/
-    [
-      {status: 400, errortype: errors.ArgumentError},
-      {status: 401, errortype: errors.UnauthorizedError},
-      {status: 403, errortype: errors.IotHubQuotaExceededError},
-      {status: 404, errortype: errors.DeviceNotFoundError},
-      {status: 413, errortype: errors.MessageTooLargeError},
-      {status: 500, errortype: errors.InternalServerError},
-      {status: 503, errortype: errors.ServiceUnavailableError},
-      {status: 504, errortype: errors.ServiceUnavailableError},
-      {status: 429, errortype: errors.ThrottlingError},
-      {status: 412, errortype: errors.InvalidEtagError},
-      {status: 999, errortype: Error},
-    ].forEach(function(errorMap) {
-      it('returns '+errorMap.errortype.prototype.name+ ' with error ' + errorMap.status, function(done) {
-        transport.status = errorMap.status;
-        twin._sendTwinRequest('fake_method', 'fake_resource', {}, 'fake_body', function(err) {
-          assert.instanceOf(err, errorMap.errortype);
-          done();
-        });
-      });
+      twin.get(function () {});
     });
   });
 
   describe('properties.reported.update', function () {
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_007: [The `update` method shall call the `updateReportedProperties` method of the `Transport` object and pass it the patch object and a callback accepting an error as argument.]*/
+    it('calls updateTwinReportedProperties on the transport', function (testCallback) {
+      var twin = new Twin(fakeTransport);
+      var fakePatch = { key: 'value' };
+      twin.get(function () {
+        twin.properties.reported.update(fakePatch, function () {});
+        assert.isTrue(fakeTransport.updateTwinReportedProperties.calledOnce);
+        assert.isTrue(fakeTransport.updateTwinReportedProperties.calledWith(fakePatch));
+        testCallback();
+      });
+    });
 
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_025: [** `properties.reported.update` shall use _sendTwinRequest to send the patch object to the service. **]**  */
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_026: [** When calling `_sendTwinRequest`, `properties.reported.update` shall pass `method`='PATCH', `resource`='/properties/reported/', `properties`={}, and `body`=the `body` parameter passed in to `reportState` as a string. **]**    */
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_027: [** `properties.reported.update` shall call `done` with the results from `_sendTwinRequest` **]**  */
-    it('calls _sendTwinRequest correctly', function(done)  {
-      var client = new FakeClient();
-      Twin.fromDeviceClient(client, function(err, twin) {
-        var sendTwinRequest = sinon.spy(twin,'_sendTwinRequest');
-        if (err) return done(err);
-        twin.properties.reported.update( { 'phone_number' : '867-5309' }, function(err) {
-          if (err) return done(err);
-          assert(sendTwinRequest.calledOnce);
-          assert.equal(sendTwinRequest.firstCall.args[0],'PATCH');
-          assert.equal(sendTwinRequest.firstCall.args[1],'/properties/reported/');
-          assert.equal(JSON.stringify(sendTwinRequest.firstCall.args[2]),'{}');
-          assert.equal(sendTwinRequest.firstCall.args[3],'{"phone_number":"867-5309"}');
-          done();
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_008: [If the callback passed to the transport is called with an error, the `callback` argument of the `update` method shall be called with that error.]*/
+    it('calls its callback with an error if updateTwinReportedProperties fails', function (testCallback) {
+      var fakeError = new Error('fake');
+      fakeTransport.updateTwinReportedProperties = sinon.stub().callsArgWith(1, fakeError);
+
+      var twin = new Twin(fakeTransport);
+      twin.get(function () {
+        twin.properties.reported.update({ reported: 'fake' }, function (err) {
+          assert.strictEqual(err, fakeError);
+          testCallback();
         });
       });
     });
 
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_031: [** `properties.reported.update` shall merge the contents of the patch object into `properties.reported` **]** */
-    it ('merges the patch contents', function(done) {
-      var client = new FakeClient();
-      Twin.fromDeviceClient(client, function(err, twin) {
-        twin.properties.reported.update( { 'phone_number' : '867-5309', 'name' : 'Jennifer' }, function(err) {
-          if (err) return done(err);
-          twin.properties.reported.update( { 'name' : 'Jenny', 'age' : 42  }, function(err) {
-            if (err) return done(err);
-            assert.equal(twin.properties.reported.name, 'Jenny');
-            assert.equal(twin.properties.reported.phone_number, '867-5309');
-            assert.equal(twin.properties.reported.age, 42);
-            done();
-          });
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_009: [Once the properties have been merged the `callback` argument of the `update` method shall be called with no argument.]*/
+    it('calls its callback with no arguments if the update succeeds', function (testCallback) {
+      var twin = new Twin(fakeTransport);
+      twin.get(function () {
+        twin.properties.reported.update({ reported: 'fake' }, function (err) {
+          assert.isUndefined(err);
+          testCallback();
         });
       });
     });
 
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_032: [** When merging the patch, if any properties are set to `null`, `properties.reported.update` shall delete that property from `properties.reported`. **]** */
-    it('handles null properties when merging', function(done) {
-      var client = new FakeClient();
-      var patchAddStuff = {
-        a: {
-          b: {
-            c: 'abc',
-            d: {
-              e: 'def'
-            }
-          }
-        }
+    /*Tests_SRS_NODE_DEVICE_TWIN_18_031: [If the callback passed to the transport is called with no error, the  `properties.reported.update` shall merge the contents of the patch object into `properties.reported`]*/
+    it('merges the patch in the reported properties', function (testCallback) {
+      var twin = new Twin(fakeTransport);
+      var fakePatch = { key: 'fake' };
+      twin.get(function () {
+        twin.properties.reported.update(fakePatch, function (err) {
+          assert.deepEqual(twin.properties.reported.key, fakePatch.key);
+          testCallback();
+        });
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_TWIN_18_032: [When merging the patch, if any properties are set to `null`, `properties.reported.update` shall delete that property from `properties.reported`.]*/
+    it('deletes reported properties set to null', function (testCallback) {
+      var twin = new Twin(fakeTransport);
+      var fakePatch = {
+        deleteMe: null
       };
-      var patchRemoveE = {
-        a: {
-          b: {
-            d: {
-              e: null
-            }
-          }
-        }
-      };
-
-      Twin.fromDeviceClient(client, function(err, twin) {
-        twin.properties.reported.update( patchAddStuff, function(err) {
-          if (err) return done(err);
-          twin.properties.reported.update( patchRemoveE, function(err) {
-            if (err) return done(err);
-            assert.equal(twin.properties.reported.a.b.c, 'abc');
-            assert.isDefined(twin.properties.reported.a.b.d);
-            assert.isUndefined(twin.properties.reported.a.b.d.e);
-            done();
-          });
+      twin.get(function () {
+        twin.properties.reported.deleteMe = 'fake';
+        twin.properties.reported.update(fakePatch, function (err) {
+          assert.isUndefined(twin.properties.reported.deleteMe);
+          testCallback();
         });
       });
     });
-
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_033: [** If `_sendTwinRequest` fails, `properties.reported.update` shall not merge the contents of the patch object into `properties.reported` **]** */
-    it ('does not merge patch if _sendTwinRequest fails', function(done) {
-      var client = new FakeClient();
-      Twin.fromDeviceClient(client, function(err, twin) {
-        client._transport.sendTwinRequest = sinon.stub(); // will cause timeout
-        twin.properties.reported.update( { 'phone_number' : '867-5309', 'name' : 'Jennifer' }, function(err) {
-          assert.instanceOf(err,errors.TimeoutError);
-          assert.isUndefined(twin.properties.reported.name);
-          done();
-        });
-      });
-    });
-
-
   });
 
-  describe('PATCH operations', function() {
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_040: [** After merging a PATCH result, the `Twin` object shall recursively fire property changed events for every changed property. **]** */
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_036: [** When a PATCH operation is received, the `Twin` object shall merge the properties into `this.properties.desired`. **]** */
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_041: [** When firing a property changed event, the `Twin` object shall name the event from the property using dot notation starting with 'properties.desired.' **]** */
-    /* Tests_SRS_NODE_DEVICE_TWIN_18_042: [** When firing a property changed event, the `Twin` object shall pass the changed value of the property as the event parameter **]** */
-    it('fires and merges', function(done) {
-      var client = new FakeClient();
+  describe('on(\'properties.desired[.path]\'', function () {
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_010: [When a listener is added for an event name starting with `properties.desired` the `enableTwinDesiredPropertiesUpdates` method of the `Transport` object shall be called with a callback function accepting an optional error argument.]*/
+    it('calls enableTwinDesiredPropertiesUpdates on the transport', function () {
+      var twin = new Twin(fakeTransport);
+      twin.on('properties.desired', function () {});
+      assert.isTrue(fakeTransport.enableTwinDesiredPropertiesUpdates.calledOnce);
+    });
 
-      var patch = {
-        desired : {
-          foo : {
-            bar : 1
-          },
-          baz : 1
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_011: [If the callback passed to the transport is called with an error, that error shall be emitted by the Twin object.]*/
+    it('emits an error if the call to enableTwinDesiredPropertiesUpdates fails', function (testCallback) {
+      var fakeError = new Error('fake');
+      fakeTransport.enableTwinDesiredPropertiesUpdates = sinon.stub().callsArgWith(0, fakeError);
+      var twin = new Twin(fakeTransport);
+      twin.on('error', function (err) {
+        assert.strictEqual(err, fakeError);
+        testCallback();
+      });
+      twin.on('properties.desired', function () {});
+    });
+
+
+    /*Tests_SRS_NODE_DEVICE_TWIN_18_045: [If a property is already set when a handler is added for that property, the `Twin` object shall fire a property changed event for the property.]*/
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_012: [When a `twinDesiredPropertiesUpdates` event is emitted by the transport, the property patch passed as argument to the event handler shall be merged with the current desired properties.]*/
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_013: [Recursively for each desired property that is part of the patch received, an event named using the convention `properties.desired[.path]` shall be fired with an argument containing the value of the property.]*/
+    it('emits an event for each property that changed', function (testCallback) {
+      var fullPatchReceived = false;
+      var prop1Received = false;
+      var prop2Received = false;
+      var prop2BarReceived = false;
+
+      var fakePatch = {
+        prop1: 'foo',
+        prop2: {
+          bar: 'baz'
         }
       };
 
-      Twin.fromDeviceClient(client, function(err, twin) {
-        if (err) return done(err);
-        var eventCount = 0;
+      function verifyAndCompleteTest() {
+        if (fullPatchReceived && prop1Received && prop2Received && prop2BarReceived) {
+          twin.removeAllListeners();
+          testCallback();
+        }
+      }
 
-        var propArray = [
-          'desired',
-          'desired.foo',
-          'desired.foo.bar',
-          'desired.baz'
-        ];
-
-        propArray.forEach(function(prop) {
-          twin.on('properties.'+prop, function(delta) {
-
-            assert.deepEqual(_.at(patch,prop)[0],delta);
-            eventCount++;
-
-            if (eventCount === propArray.length) {
-              propArray.forEach(function(prop) {
-                assert.deepEqual(_.at(twin.properties, prop), _.at(patch, prop));
-              });
-              done();
-            }
-
-          });
+      var twin = new Twin(fakeTransport);
+      twin.get(function () {
+        twin.on('properties.desired', function (delta) {
+          assert.deepEqual(delta.prop1, fakePatch.prop1);
+          assert.deepEqual(delta.prop2, fakePatch.prop2);
+          fullPatchReceived = true;
+          verifyAndCompleteTest();
         });
 
-        client._transport._receiver.emit('post', JSON.stringify(patch.desired));
+        twin.on('properties.desired.prop1', function (delta) {
+          assert.strictEqual(delta, fakePatch.prop1);
+          prop1Received = true;
+          verifyAndCompleteTest();
+        });
 
+        twin.on('properties.desired.prop2', function (delta) {
+          assert.strictEqual(delta, fakePatch.prop2);
+          prop2Received = true;
+          verifyAndCompleteTest();
+        });
+
+        twin.on('properties.desired.prop2.bar', function (delta) {
+          assert.strictEqual(delta, fakePatch.prop2.bar);
+          prop2BarReceived = true;
+          verifyAndCompleteTest();
+        });
+
+        fakeTransport.emit('twinDesiredPropertiesUpdate', fakePatch);
       });
     });
-
   });
 });

--- a/device/core/test/_twin_test.js
+++ b/device/core/test/_twin_test.js
@@ -12,7 +12,7 @@ var sinon = require('sinon');
 var _ = require('lodash');
 
 describe('Twin', function () {
-  var fakeTransport, fakeTwin;
+  var fakeTransport, fakeTwin, fakeRetryPolicy;
 
   beforeEach(function () {
     fakeTwin = {
@@ -22,6 +22,11 @@ describe('Twin', function () {
       reported: {
         key: 'value'
       }
+    };
+
+    fakeRetryPolicy = {
+      shouldRetry: function () { return false; },
+      getNextRetryTimeout: function () { return 0; }
     };
 
     fakeTransport = new EventEmitter();
@@ -34,7 +39,7 @@ describe('Twin', function () {
   describe('#constructor', function () {
     /*Tests_SRS_NODE_DEVICE_TWIN_16_001: [The `Twin` constructor shall subscribe to the `onDesiredPropertiesUpdate` event off the `transport` object.]*/
     it('subscribes to the twinDesiredPropertiesUpdate event on the transport', function () {
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       assert.isTrue(fakeTransport.on.calledOnce);
       assert.isTrue(fakeTransport.on.calledWith('twinDesiredPropertiesUpdate'));
     });
@@ -43,7 +48,7 @@ describe('Twin', function () {
   describe('#get', function () {
     /*Tests_SRS_NODE_DEVICE_TWIN_16_002: [The `get` method shall call the `getTwin` method of the `Transport` object with a callback.]*/
     it('calls getTwin on the transpport', function () {
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       twin.get(function () {});
       assert.isTrue(fakeTransport.getTwin.calledOnce);
     });
@@ -51,7 +56,7 @@ describe('Twin', function () {
     /*Tests_SRS_NODE_DEVICE_TWIN_16_004: [If the callback passed to the `getTwin` method is called with no error and a `TwinProperties` object, these properties shall be merged with the current instance properties.]*/
     /*Tests_SRS_NODE_DEVICE_TWIN_16_005: [Once the properties have been merged the `callback` method passed to the call to `get` shall be called with a first argument that is `null` and a second argument that is the current `Twin` instance (`this`).]*/
     it('calls its callback with the twin after it is merged', function (testCallback) {
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       twin.get(function (err, twin) {
         assert.deepEqual(twin.properties.desired, fakeTwin.desired);
         assert.deepEqual(twin.properties.reported.key, fakeTwin.reported.key);
@@ -63,7 +68,7 @@ describe('Twin', function () {
     it('calls its callback with an error if the transport encounters an error', function (testCallback) {
       var fakeError = new Error('fake');
       fakeTransport.getTwin = sinon.stub().callsArgWith(0, fakeError);
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       twin.get(function (err) {
         assert.strictEqual(err, fakeError);
         testCallback();
@@ -72,7 +77,7 @@ describe('Twin', function () {
 
     /*Tests_SRS_NODE_DEVICE_TWIN_16_006: [For each desired property that is part of the `TwinProperties` object received, an event named after the path to this property shall be fired.]*/
     it('fires events for the new properties that have been merged', function (testCallback) {
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       var genericEventReceived = false;
       var specificEventReceived = false;
       twin.on('properties.desired', function (delta) {
@@ -97,7 +102,7 @@ describe('Twin', function () {
   describe('properties.reported.update', function () {
     /*Tests_SRS_NODE_DEVICE_TWIN_16_007: [The `update` method shall call the `updateReportedProperties` method of the `Transport` object and pass it the patch object and a callback accepting an error as argument.]*/
     it('calls updateTwinReportedProperties on the transport', function (testCallback) {
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       var fakePatch = { key: 'value' };
       twin.get(function () {
         twin.properties.reported.update(fakePatch, function () {});
@@ -112,7 +117,7 @@ describe('Twin', function () {
       var fakeError = new Error('fake');
       fakeTransport.updateTwinReportedProperties = sinon.stub().callsArgWith(1, fakeError);
 
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       twin.get(function () {
         twin.properties.reported.update({ reported: 'fake' }, function (err) {
           assert.strictEqual(err, fakeError);
@@ -123,10 +128,10 @@ describe('Twin', function () {
 
     /*Tests_SRS_NODE_DEVICE_TWIN_16_009: [Once the properties have been merged the `callback` argument of the `update` method shall be called with no argument.]*/
     it('calls its callback with no arguments if the update succeeds', function (testCallback) {
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       twin.get(function () {
         twin.properties.reported.update({ reported: 'fake' }, function (err) {
-          assert.isUndefined(err);
+          assert.isNull(err);
           testCallback();
         });
       });
@@ -134,7 +139,7 @@ describe('Twin', function () {
 
     /*Tests_SRS_NODE_DEVICE_TWIN_18_031: [If the callback passed to the transport is called with no error, the  `properties.reported.update` shall merge the contents of the patch object into `properties.reported`]*/
     it('merges the patch in the reported properties', function (testCallback) {
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       var fakePatch = { key: 'fake' };
       twin.get(function () {
         twin.properties.reported.update(fakePatch, function (err) {
@@ -146,7 +151,7 @@ describe('Twin', function () {
 
     /*Tests_SRS_NODE_DEVICE_TWIN_18_032: [When merging the patch, if any properties are set to `null`, `properties.reported.update` shall delete that property from `properties.reported`.]*/
     it('deletes reported properties set to null', function (testCallback) {
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       var fakePatch = {
         deleteMe: null
       };
@@ -163,7 +168,7 @@ describe('Twin', function () {
   describe('on(\'properties.desired[.path]\'', function () {
     /*Tests_SRS_NODE_DEVICE_TWIN_16_010: [When a listener is added for an event name starting with `properties.desired` the `enableTwinDesiredPropertiesUpdates` method of the `Transport` object shall be called with a callback function accepting an optional error argument.]*/
     it('calls enableTwinDesiredPropertiesUpdates on the transport', function () {
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       twin.on('properties.desired', function () {});
       assert.isTrue(fakeTransport.enableTwinDesiredPropertiesUpdates.calledOnce);
     });
@@ -172,7 +177,7 @@ describe('Twin', function () {
     it('emits an error if the call to enableTwinDesiredPropertiesUpdates fails', function (testCallback) {
       var fakeError = new Error('fake');
       fakeTransport.enableTwinDesiredPropertiesUpdates = sinon.stub().callsArgWith(0, fakeError);
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       twin.on('error', function (err) {
         assert.strictEqual(err, fakeError);
         testCallback();
@@ -204,7 +209,7 @@ describe('Twin', function () {
         }
       }
 
-      var twin = new Twin(fakeTransport);
+      var twin = new Twin(fakeTransport, fakeRetryPolicy, 0);
       twin.get(function () {
         twin.on('properties.desired', function (delta) {
           assert.deepEqual(delta.prop1, fakePatch.prop1);
@@ -232,6 +237,26 @@ describe('Twin', function () {
         });
 
         fakeTransport.emit('twinDesiredPropertiesUpdate', fakePatch);
+      });
+    });
+  });
+
+  describe('#setRetryPolicy', function () {
+    /*Tests_SRS_NODE_DEVICE_TWIN_16_014: [the `retryPolicy` object passed to the `setRetryPolicy` method shall be used to retry any subsequent operation.]*/
+    it('uses the retry policy passed as an argument in the subsequent calls', function (testCallback) {
+      var testPolicy = {
+        shouldRetry: sinon.stub().returns(false),
+        nextRetryTimeout: sinon.stub().returns(-1)
+      };
+      fakeTransport.getTwin = sinon.stub().callsArgWith(0, new Error('fake'));
+
+      var twin = new Twin(fakeTransport, fakeRetryPolicy);
+      twin.setRetryPolicy(testPolicy);
+      twin.get(function() {
+        assert.isTrue(testPolicy.shouldRetry.calledOnce);
+        assert.isTrue(testPolicy.nextRetryTimeout.notCalled); //shouldRetry being false, nextRetryTimeout should not have been called.
+        assert.isTrue(fakeTransport.getTwin.calledOnce);
+        testCallback();
       });
     });
   });

--- a/device/core/test/fake_transport.js
+++ b/device/core/test/fake_transport.js
@@ -52,6 +52,10 @@ function FakeTransport() {
   this.disableC2D = function (callback) {
     callback();
   };
+
+  this.getTwin = function (callback) {
+    callback(null, { desired: {}, reported: {} });
+  };
 }
 
 util.inherits(FakeTransport, EventEmitter);

--- a/device/transport/http/devdoc/http_requirements.md
+++ b/device/transport/http/devdoc/http_requirements.md
@@ -217,21 +217,21 @@ Host: <config.host>
 
 **SRS_NODE_DEVICE_HTTP_16_007: [**The `updateSharedAccessSignature` method shall call the `done` callback with a null error object and a SharedAccessSignatureUpdated object as a result, indicating that the client does not need to reestablish the transport connection.**]**
 
-### getTwinReceiver(done: (err?: Error, receiver?: any) => void): void;
+### getTwin(done: (err?: Error, twin?: any) => void): void;
 
-**SRS_NODE_DEVICE_HTTP_16_020: [** `getTwinReceiver` shall throw a `NotImplementedError`. **]**
+**SRS_NODE_DEVICE_HTTP_16_020: [** `getTwin` shall throw a `NotImplementedError`. **]**
 
-### sendTwinRequest(method: string, resource: string, properties: { [key: string]: any;}, body: any, done?: (err?: Error, result?: any) => void): void;
+### updateTwinReportedProperties(done: (err?: Error) => void): void
 
-**SRS_NODE_DEVICE_HTTP_16_021: [** `sendTwinRequest` shall throw a `NotImplementedError`. **]**
+**SRS_NODE_DEVICE_HTTP_16_034: [** `updateTwinReportedProperties` shall throw a `NotImplementedError`. **]**
 
-### enableTwin(callback: (err?: Error) => void): void;
+### enableTwinDesiredPropertiesUpdates(done: (err?: Error) => void): void
 
-**SRS_NODE_DEVICE_HTTP_16_022: [** `enableTwin` shall throw a `NotImplementedError`. **]**
+**SRS_NODE_DEVICE_HTTP_16_035: [** `enableTwinDesiredPropertiesUpdates` shall throw a `NotImplementedError`. **]**
 
-### disableTwin(callback: (err?: Error) => void): void;
+### disableTwinDesiredPropertiesUpdates(done: (err?: Error) => void): void
 
-**SRS_NODE_DEVICE_HTTP_16_023: [** `disableTwin` shall throw a `NotImplementedError`. **]**
+**SRS_NODE_DEVICE_HTTP_16_036: [** `disableTwinDesiredPropertiesUpdates` shall throw a `NotImplementedError`. **]**
 
 ### sendMethodResponse(response: DeviceMethodResponse, done?: (err?: Error, result?: any) => void): void;
 

--- a/device/transport/http/package.json
+++ b/device/transport/http/package.json
@@ -33,7 +33,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 92 --branches 83 --lines 93 --functions 89"
+    "check-cover": "istanbul check-coverage --statements 92 --branches 83 --lines 94 --functions 90"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/http/src/http.ts
+++ b/device/transport/http/src/http.ts
@@ -12,7 +12,7 @@ import { Http as Base } from 'azure-iot-http-base';
 import { endpoint, errors, results, Message, AuthenticationProvider, AuthenticationType, TransportConfig } from 'azure-iot-common';
 import { translateError } from './http_errors.js';
 import { IncomingMessage } from 'http';
-import { DeviceMethodResponse, Client, X509AuthenticationProvider, SharedAccessSignatureAuthenticationProvider } from 'azure-iot-device';
+import { DeviceMethodResponse, Client, X509AuthenticationProvider, SharedAccessSignatureAuthenticationProvider, TwinProperties } from 'azure-iot-device';
 
 // tslint:disable-next-line:no-var-requires
 const packageJson = require('../package.json');
@@ -499,34 +499,32 @@ export class Http extends EventEmitter implements Client.Transport {
   /**
    * @private
    */
-  getTwinReceiver(done: (err?: Error, receiver?: any) => void): void {
-    /*Codes_SRS_NODE_DEVICE_HTTP_16_020: [`getTwinReceiver` shall throw a `NotImplementedError`.]*/
+  getTwin(done: (err?: Error, twin?: TwinProperties) => void): void {
+    /*Codes_SRS_NODE_DEVICE_HTTP_16_020: [`getTwin` shall throw a `NotImplementedError`.]*/
     throw new errors.NotImplementedError('Twin is not implemented over HTTP.');
   }
 
   /**
    * @private
    */
-  sendTwinRequest(method: string, resource: string, properties: {
-      [key: string]: any;
-  }, body: any, done?: (err?: Error, result?: any) => void): void {
-    /*Codes_SRS_NODE_DEVICE_HTTP_16_021: [`sendTwinRequest` shall throw a `NotImplementedError`.]*/
+  updateTwinReportedProperties(done: (err?: Error) => void): void {
+    /*Codes_SRS_NODE_DEVICE_HTTP_16_034: [`updateTwinReportedProperties` shall throw a `NotImplementedError`.]*/
     throw new errors.NotImplementedError('Twin is not implemented over HTTP.');
   }
 
   /**
    * @private
    */
-  enableTwin(callback: (err?: Error) => void): void {
-    /*Codes_SRS_NODE_DEVICE_HTTP_16_022: [`enableTwin` shall throw a `NotImplementedError`.]*/
+  enableTwinDesiredPropertiesUpdates(done: (err?: Error) => void): void {
+    /*Codes_SRS_NODE_DEVICE_HTTP_16_035: [`enableTwinDesiredPropertiesUpdates` shall throw a `NotImplementedError`.]*/
     throw new errors.NotImplementedError('Twin is not implemented over HTTP.');
   }
 
   /**
    * @private
    */
-  disableTwin(callback: (err?: Error) => void): void {
-    /*Codes_SRS_NODE_DEVICE_HTTP_16_023: [`disableTwin` shall throw a `NotImplementedError`.]*/
+  disableTwinDesiredPropertiesUpdates(done: (err?: Error) => void): void {
+    /*Codes_SRS_NODE_DEVICE_HTTP_16_036: [`disableTwinDesiredPropertiesUpdates` shall throw a `NotImplementedError`.]*/
     throw new errors.NotImplementedError('Twin is not implemented over HTTP.');
   }
 

--- a/device/transport/http/test/_http_test.js
+++ b/device/transport/http/test/_http_test.js
@@ -779,19 +779,19 @@ describe('HttpReceiver', function () {
     });
   });
 
-  /*Tests_SRS_NODE_DEVICE_HTTP_16_020: [`getTwinReceiver` shall throw a `NotImplementedError`.]*/
-  /*Tests_SRS_NODE_DEVICE_HTTP_16_021: [`sendTwinRequest` shall throw a `NotImplementedError`.]*/
-  /*Tests_SRS_NODE_DEVICE_HTTP_16_022: [`enableTwin` shall throw a `NotImplementedError`.]*/
-  /*Tests_SRS_NODE_DEVICE_HTTP_16_023: [`disableTwin` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_HTTP_16_020: [`getTwin` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_HTTP_16_034: [`updateTwinReportedProperties` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_HTTP_16_035: [`enableTwinDesiredPropertiesUpdates` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_HTTP_16_036: [`disableTwinDesiredPropertiesUpdates` shall throw a `NotImplementedError`.]*/
   /*Tests_SRS_NODE_DEVICE_HTTP_16_024: [`sendMethodResponse` shall throw a `NotImplementedError`.]*/
   /*Tests_SRS_NODE_DEVICE_HTTP_16_025: [`onDeviceMethod` shall throw a `NotImplementedError`.]*/
   /*Tests_SRS_NODE_DEVICE_HTTP_16_026: [`enableMethods` shall throw a `NotImplementedError`.]*/
   /*Tests_SRS_NODE_DEVICE_HTTP_16_027: [`disableMethods` shall throw a `NotImplementedError`.]*/
   [
-    'getTwinReceiver',
-    'sendTwinRequest',
-    'enableTwin',
-    'disableTwin',
+    'getTwin',
+    'updateTwinReportedProperties',
+    'enableTwinDesiredPropertiesUpdates',
+    'disableTwinDesiredPropertiesUpdates',
     'sendMethodResponse',
     'onDeviceMethod',
     'enableMethods',


### PR DESCRIPTION
Penultimate PR containing the device client and http transport changes for the refactored twin (last one of this cycle will be about adding retries)